### PR TITLE
refactor(.Net version): :arrow_down: Change project to target .NetSta…

### DIFF
--- a/src/Chatter.Rest.Hal/Builders/EmbeddedResourceCollectionBuilder.cs
+++ b/src/Chatter.Rest.Hal/Builders/EmbeddedResourceCollectionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Chatter.Rest.Hal.Builders.Stages;
+﻿using System.Collections.Generic;
+using Chatter.Rest.Hal.Builders.Stages;
 
 namespace Chatter.Rest.Hal.Builders;
 

--- a/src/Chatter.Rest.Hal/Builders/LinkCollectionBuilder.cs
+++ b/src/Chatter.Rest.Hal/Builders/LinkCollectionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Chatter.Rest.Hal.Builders.Stages;
+﻿using System.Collections.Generic;
+using Chatter.Rest.Hal.Builders.Stages;
 
 namespace Chatter.Rest.Hal.Builders;
 

--- a/src/Chatter.Rest.Hal/Builders/LinkObjectBuilder.cs
+++ b/src/Chatter.Rest.Hal/Builders/LinkObjectBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Chatter.Rest.Hal.Builders.Stages;
+﻿using System;
+using Chatter.Rest.Hal.Builders.Stages;
 using Chatter.Rest.Hal.Builders.Stages.Embedded;
 using Chatter.Rest.Hal.Builders.Stages.Resource;
 

--- a/src/Chatter.Rest.Hal/Builders/LinkObjectCollectionBuilder.cs
+++ b/src/Chatter.Rest.Hal/Builders/LinkObjectCollectionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Chatter.Rest.Hal.Builders.Stages;
+﻿using System.Collections.Generic;
+using Chatter.Rest.Hal.Builders.Stages;
 using Chatter.Rest.Hal.Builders.Stages.Embedded;
 using Chatter.Rest.Hal.Builders.Stages.Resource;
 

--- a/src/Chatter.Rest.Hal/Builders/ResourceCollectionBuilder.cs
+++ b/src/Chatter.Rest.Hal/Builders/ResourceCollectionBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Chatter.Rest.Hal.Builders.Stages;
+﻿using System.Collections.Generic;
+using Chatter.Rest.Hal.Builders.Stages;
 using Chatter.Rest.Hal.Builders.Stages.Embedded;
 
 namespace Chatter.Rest.Hal.Builders;

--- a/src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
+++ b/src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>0.3</Version>
+    <Version>0.4</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A dotnet/c# implementation of the Hypertext Application Language (HAL+json) specification for RESTful Web Apis</Description>
@@ -21,5 +21,7 @@
       <_Parameter1>$(AssemblyName).Tests</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
-
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="6.0.3" />
+  </ItemGroup>
 </Project>

--- a/src/Chatter.Rest.Hal/Converters/EmbeddedResourceCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/EmbeddedResourceCollectionConverter.cs
@@ -1,4 +1,10 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class EmbeddedResourceCollectionConverter : JsonConverter<EmbeddedResourceCollection>
 {

--- a/src/Chatter.Rest.Hal/Converters/EmbeddedResourceConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/EmbeddedResourceConverter.cs
@@ -1,4 +1,10 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class EmbeddedResourceConverter : JsonConverter<EmbeddedResource>
 {

--- a/src/Chatter.Rest.Hal/Converters/LinkCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkCollectionConverter.cs
@@ -1,4 +1,10 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class LinkCollectionConverter : JsonConverter<LinkCollection>
 {

--- a/src/Chatter.Rest.Hal/Converters/LinkConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkConverter.cs
@@ -1,4 +1,10 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class LinkConverter : JsonConverter<Link>
 {

--- a/src/Chatter.Rest.Hal/Converters/LinkObjectCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkObjectCollectionConverter.cs
@@ -1,4 +1,10 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class LinkObjectCollectionConverter : JsonConverter<LinkObjectCollection>
 {

--- a/src/Chatter.Rest.Hal/Converters/LinkObjectConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkObjectConverter.cs
@@ -1,4 +1,9 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class LinkObjectConverter : JsonConverter<LinkObject>
 {

--- a/src/Chatter.Rest.Hal/Converters/ResourceCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/ResourceCollectionConverter.cs
@@ -1,4 +1,10 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class ResourceCollectionConverter : JsonConverter<ResourceCollection>
 {

--- a/src/Chatter.Rest.Hal/Converters/ResourceConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/ResourceConverter.cs
@@ -1,4 +1,9 @@
-﻿namespace Chatter.Rest.Hal.Converters;
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace Chatter.Rest.Hal.Converters;
 
 public class ResourceConverter : JsonConverter<Resource>
 {

--- a/src/Chatter.Rest.Hal/EmbeddedResource.cs
+++ b/src/Chatter.Rest.Hal/EmbeddedResource.cs
@@ -1,4 +1,8 @@
-﻿namespace Chatter.Rest.Hal;
+﻿using System;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
+
+namespace Chatter.Rest.Hal;
 
 [JsonConverter(typeof(EmbeddedResourceConverter))]
 public sealed record EmbeddedResource : IHalPart
@@ -12,6 +16,6 @@ public sealed record EmbeddedResource : IHalPart
 		Name = name;
 	}
 
-	public string Name { get; init; }
-	public ResourceCollection Resources { get; init; } = new();
+	public string Name { get; }
+	public ResourceCollection Resources { get; set; } = new();
 }

--- a/src/Chatter.Rest.Hal/EmbeddedResourceCollection.cs
+++ b/src/Chatter.Rest.Hal/EmbeddedResourceCollection.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
 
 namespace Chatter.Rest.Hal;
 

--- a/src/Chatter.Rest.Hal/GlobalUsings.cs
+++ b/src/Chatter.Rest.Hal/GlobalUsings.cs
@@ -1,4 +1,0 @@
-﻿global using Chatter.Rest.Hal.Converters;
-global using System.Text.Json;
-global using System.Text.Json.Nodes;
-global using System.Text.Json.Serialization;

--- a/src/Chatter.Rest.Hal/Link.cs
+++ b/src/Chatter.Rest.Hal/Link.cs
@@ -1,4 +1,8 @@
-﻿namespace Chatter.Rest.Hal;
+﻿using System;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
+
+namespace Chatter.Rest.Hal;
 
 [JsonConverter(typeof(LinkConverter))]
 public sealed record Link : IHalPart
@@ -12,6 +16,6 @@ public sealed record Link : IHalPart
 		Rel = rel;
 	}
 
-	public string Rel { get; init; }
-	public LinkObjectCollection LinkObjects { get; init; } = new();
+	public string Rel { get; }
+	public LinkObjectCollection LinkObjects { get; set; } = new();
 }

--- a/src/Chatter.Rest.Hal/LinkCollection.cs
+++ b/src/Chatter.Rest.Hal/LinkCollection.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
 
 namespace Chatter.Rest.Hal;
 

--- a/src/Chatter.Rest.Hal/LinkObject.cs
+++ b/src/Chatter.Rest.Hal/LinkObject.cs
@@ -1,4 +1,8 @@
-﻿namespace Chatter.Rest.Hal;
+﻿using System;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
+
+namespace Chatter.Rest.Hal;
 
 /// <summary>
 /// A Link Object represents a hyperlink from the containing resource to a URI.
@@ -28,7 +32,7 @@ public sealed record LinkObject : IHalPart
 	/// If the value is a URI Template then the Link Object SHOULD have a
 	/// "templated" attribute whose value is true.
 	/// </remarks>
-	public string Href { get; init; }
+	public string Href { get; }
 
 	/// <summary>
 	/// The OPTIONAL templated property of the Link Object as defined by the HAL specification
@@ -44,7 +48,7 @@ public sealed record LinkObject : IHalPart
 	/// Its value SHOULD be considered false if it is undefined or any other
 	/// value than true.
 	/// </remarks>
-	public bool? Templated { get; init; }
+	public bool? Templated { get; set; }
 
 	/// <summary>
 	/// The OPTIONAL type property of the Link Object as defined by the HAL specification
@@ -59,7 +63,7 @@ public sealed record LinkObject : IHalPart
 	/// Its value is a string used as a hint to indicate the media type
 	/// expected when dereferencing the target resource.
 	/// </remarks>
-	public string? Type { get; init; }
+	public string? Type { get; set; }
 
 	/// <summary>
 	/// The OPTIONAL depreciation property of the Link Object as defined by the HAL specification
@@ -81,7 +85,7 @@ public sealed record LinkObject : IHalPart
 	/// value so that a client manitainer can easily find information about
 	/// the deprecation.
 	/// </remarks>
-	public string? Deprecation { get; init; }
+	public string? Deprecation { get; set; }
 
 	/// <summary>
 	/// The OPTIONAL name property of the Link Object as defined by the HAL specification
@@ -96,7 +100,7 @@ public sealed record LinkObject : IHalPart
 	/// Its value MAY be used as a secondary key for selecting Link Objects
 	/// which share the same relation type.
 	/// </remarks>
-	public string? Name { get; init; }
+	public string? Name { get; set; }
 
 	/// <summary>
 	/// The OPTIONAL profile property of the Link Object as defined by the HAL specification
@@ -111,7 +115,7 @@ public sealed record LinkObject : IHalPart
 	/// Its value is a string which is a URI that hints about the profile(as
 	/// defined by [I-D.wilde-profile-link]) of the target resource.
 	/// </remarks>
-	public string? Profile { get; init; }
+	public string? Profile { get; set; }
 
 	/// <summary>
 	/// The OPTIONAL title property of the Link Object as defined by the HAL specification
@@ -126,7 +130,7 @@ public sealed record LinkObject : IHalPart
 	/// Its value is a string and is intended for labelling the link with a
 	/// human-readable identifier(as defined by [RFC5988]).
 	/// </remarks>
-	public string? Title { get; init; }
+	public string? Title { get; set; }
 
 	/// <summary>
 	/// The OPTIONAL hreflang property of the Link Object as defined by the HAL specification
@@ -141,5 +145,5 @@ public sealed record LinkObject : IHalPart
 	/// Its value is a string and is intended for indicating the language of
 	/// the target resource(as defined by [RFC5988]).
 	/// </remarks>
-	public string? Hreflang { get; init; }
+	public string? Hreflang { get; set; }
 }

--- a/src/Chatter.Rest.Hal/LinkObjectCollection.cs
+++ b/src/Chatter.Rest.Hal/LinkObjectCollection.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
 
 namespace Chatter.Rest.Hal;
 

--- a/src/Chatter.Rest.Hal/Resource.cs
+++ b/src/Chatter.Rest.Hal/Resource.cs
@@ -1,4 +1,8 @@
-﻿namespace Chatter.Rest.Hal;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
+
+namespace Chatter.Rest.Hal;
 
 [JsonConverter(typeof(ResourceConverter))]
 public sealed record Resource : IHalPart
@@ -7,9 +11,9 @@ public sealed record Resource : IHalPart
 	public Resource() { }
 	public Resource(object? state) => StateImpl = state;
 
-	internal object? StateImpl { get; init; }
-	public LinkCollection Links { get; init; } = new();
-	public EmbeddedResourceCollection EmbeddedResources { get; init; } = new();
+	internal object? StateImpl { get; set; }
+	public LinkCollection Links { get; set; } = new();
+	public EmbeddedResourceCollection EmbeddedResources { get; set; } = new();
 
 	public T? State<T>() where T : class
 	{

--- a/src/Chatter.Rest.Hal/ResourceCollection.cs
+++ b/src/Chatter.Rest.Hal/ResourceCollection.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
+using Chatter.Rest.Hal.Converters;
 
 namespace Chatter.Rest.Hal;
 


### PR DESCRIPTION
…ndard2.0

.Net 6 is not compatible with with older versions of .Net Framework. Targetting .NetStandard2.0 allows better backwards compatability

Many record init properties are either gone (if available via the constructor) or are changed to setters