### PR TITLE
fix(warnings): resolve CS8602/CS8603/CS8604/CS1066 compiler warnings

### DIFF
--- a/src/Chatter.Rest.Hal/Builders/EmbeddedResourceBuilder.cs
+++ b/src/Chatter.Rest.Hal/Builders/EmbeddedResourceBuilder.cs
@@ -33,7 +33,7 @@ public class EmbeddedResourceBuilder : HalBuilder<EmbeddedResource>, IAddResourc
 	///<inheritdoc/>
 	public IEmbeddedResourceCreationStage AddResource(object? state) => _resourceCollectionBuilder.AddResource(state);
 
-	IEmbeddedResourceCreationStage IAddResourceStage.AddResources<T>(IEnumerable<T> resources, Action<T, IEmbeddedResourceCreationStage>? builder = null)
+	IEmbeddedResourceCreationStage IAddResourceStage.AddResources<T>(IEnumerable<T> resources, Action<T, IEmbeddedResourceCreationStage>? builder)
 		=> _resourceCollectionBuilder.AddResources(resources, builder);
 
 	/// <summary>

--- a/src/Chatter.Rest.Hal/Converters/LinkConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkConverter.cs
@@ -55,7 +55,7 @@ public class LinkConverter : JsonConverter<Link>
         // If the value is an object, ensure it contains an href (required by HAL) before deserializing.
         if (kvp.Value is JsonObject obj)
         {
-            if (obj["href"] == null || obj["href"].ToJsonString() == "null")
+            if (obj["href"] == null || obj["href"]?.ToJsonString() == "null")
             {
                 // Not a valid Link Object shape
                 return null;
@@ -75,7 +75,7 @@ public class LinkConverter : JsonConverter<Link>
                 {
                     return null;
                 }
-                if (itemObj["href"] == null || itemObj["href"].ToJsonString() == "null")
+                if (itemObj["href"] == null || itemObj["href"]?.ToJsonString() == "null")
                 {
                     return null;
                 }

--- a/test/Chatter.Rest.Hal.Tests/Converters/LinkConvertersTests.cs
+++ b/test/Chatter.Rest.Hal.Tests/Converters/LinkConvertersTests.cs
@@ -13,7 +13,7 @@ namespace Chatter.Rest.Hal.Tests.Converters
             var links = JsonSerializer.Deserialize<Chatter.Rest.Hal.LinkCollection>(json);
 		    Assert.NotNull(links);
 		    Assert.Single(links);
-		    var link = links.First();
+		    var link = links!.First();
 		    Assert.Equal("self", link.Rel);
 		    Assert.Single(link.LinkObjects);
 		    Assert.Equal("/orders/123", link.LinkObjects.First().Href);
@@ -25,7 +25,7 @@ namespace Chatter.Rest.Hal.Tests.Converters
 			var links = JsonSerializer.Deserialize<Chatter.Rest.Hal.LinkCollection>(json);
 			Assert.NotNull(links);
 			Assert.Single(links);
-			var link = links.First();
+			var link = links!.First();
 			Assert.Equal("friends", link.Rel);
 			Assert.Equal(2, link.LinkObjects.Count);
 			Assert.Equal("/users/1", link.LinkObjects.First().Href);
@@ -37,7 +37,7 @@ namespace Chatter.Rest.Hal.Tests.Converters
 			var links = JsonSerializer.Deserialize<Chatter.Rest.Hal.LinkCollection>(json);
 			Assert.NotNull(links);
 			Assert.Single(links);
-			var link = links.First();
+			var link = links!.First();
 			Assert.Equal("next", link.Rel);
 			Assert.Empty(link.LinkObjects);
 		}
@@ -49,7 +49,7 @@ namespace Chatter.Rest.Hal.Tests.Converters
 			Assert.NotNull(links);
 			// should skip the empty key and only include the valid rel
 			Assert.Single(links);
-			Assert.Equal("valid", links.First().Rel);
+			Assert.Equal("valid", links!.First().Rel);
 		}
 		[Fact]
 		public void RoundTrip_Serialization_LinkCollection_Preserves_Data()

--- a/test/Chatter.Rest.Hal.Tests/ResourceTests.cs
+++ b/test/Chatter.Rest.Hal.Tests/ResourceTests.cs
@@ -231,7 +231,7 @@ public class ResourceTests
 	public void Getting_Resource_Embedded_Should_Return_New_EmbeddedResourceollection_If_EmbeddedCreator_Returns_Null()
 	{
 		var node = JsonSerializer.SerializeToNode(new { foo = 1, bar = "baz" });
-		Func<EmbeddedResourceCollection> embeddedCollection = () => null;
+		Func<EmbeddedResourceCollection> embeddedCollection = () => null!;
 		var res = new Resource(node, () => node!.AsObject(), () => new LinkCollection(), embeddedCollection);
 
 		var embedded = res.Embedded;


### PR DESCRIPTION
- CS8604 x4: null-forgiving operator on LinkConvertersTests deserialized result
- CS8603 x1: null-forgiving operator on intentional null lambda in ResourceTests
- CS8602 x2: null-conditional on JsonNode indexer in LinkConverter
- CS1066 x1: remove redundant default param from explicit interface impl in EmbeddedResourceBuilder