### PR TITLE
fix: cicd deploy stage never triggered on PR merge to main

### DIFF
--- a/.github/workflows/codegen-cicd.yml
+++ b/.github/workflows/codegen-cicd.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - 'feature/**'
+      - main
     paths:
       - '.github/workflows/codegen-cicd.yml'
       - '**/src/Chatter.Rest.Hal.CodeGenerators/**'
@@ -36,7 +37,6 @@ jobs:
   build:
     name: build
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
 
     steps:
       - name: Checkout

--- a/.github/workflows/hal-cicd.yml
+++ b/.github/workflows/hal-cicd.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - 'feature/**'
+      - main
     paths:
       - '**/src/Chatter.Rest.Hal/**'
       - '.github/workflows/hal-cicd.yml'


### PR DESCRIPTION
## Root Cause

Two bugs prevented the `deploy` job from ever running after a PR merge.

**Bug 1 (both workflows):** PR merge fires a `push` event to `main` — not a `pull_request` event. Neither workflow had a `push` trigger for `main`, so `deploy`'s `if: github.ref == 'refs/heads/main'` was never satisfied.

**Bug 2 (`codegen-cicd.yml` only):** The `build` job had `if: github.event_name != 'pull_request' || github.event.pull_request.merged == true` — this skipped the build on all normal PR events (`opened`, `synchronize`, `reopened`) since `merged == false` at those times. CI checks never ran for codegen PRs.

## Changes

- `hal-cicd.yml`: added `main` to `push.branches`
- `codegen-cicd.yml`: added `main` to `push.branches`
- `codegen-cicd.yml`: removed broken `if` condition from `build` job

## Test plan
- [ ] Merge a PR to `main` that touches `src/Chatter.Rest.Hal/**` — verify `Hal CI/CD` deploy stage runs
- [ ] Merge a PR to `main` that touches `src/Chatter.Rest.Hal.CodeGenerators/**` — verify `CodeGen CI/CD` deploy stage runs
- [ ] Open a PR targeting `main` touching codegen paths — verify `build` job runs (CI check not skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)