### PR TITLE
docs: add technical architecture, serialization, and API reference documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,55 +1,520 @@
-API Reference — Chatter.Rest.Hal (concise)
+# API Reference — Chatter.Rest.Hal
 
-This short reference lists the public types and fluent methods used in the examples. It is intended to align with the public API surface used by tests and examples.
+- **Package:** `Chatter.Rest.Hal`
+- **Media type:** `application/hal+json`
+- **Namespace (unless noted):** `Chatter.Rest.Hal`
 
-ResourceBuilder (fluent)
-- WithState(object state)
-  - Start building a resource with a state object (anonymous or typed).
-- AddSelf()
-  - Shortcut to add the `self` relation. Returns a LinkBuilder to attach a Link Object.
-- AddCuries()
-  - Shortcut to add the `curies` relation for namespaced relations.
-- AddLink(string rel)
-  - Start a link relation; returns LinkBuilder for the named relation.
-- AddEmbedded(string rel)
-  - Start an embedded collection under the given relation; returns an EmbeddedBuilder.
-- Build()
-  - Finalize and return a Resource object representing the HAL document.
+---
 
-LinkBuilder
-- AddLinkObject(string href)
-  - Add a link object with the specified href and return a LinkObjectBuilder to set metadata.
+## 1. Entry Points
 
-LinkObjectBuilder
-- Templated()
-  - Mark the last link object as templated (href contains variables).
-- WithTitle(string title)
-  - Set a title on the link object.
-- WithName(string name)
-  - Set the name (useful for curies).
+```csharp
+// Chatter.Rest.Hal.Builders namespace
+public class ResourceBuilder
+{
+    // Start building a resource with no state.
+    public static IResourceCreationStage New();
 
-EmbeddedBuilder
-- AddResource(object state)
-  - Add one embedded resource and returns a ResourceBuilder for that embedded resource so you can add links to it.
-- AddResources<T>(IEnumerable<T> items, Action<T, ResourceBuilder> configure)
-  - Add a list of embedded resources and configure each via the provided callback.
+    // Start building a resource with an existing state object.
+    public static IResourceCreationStage WithState(object state);
+}
+```
 
-Resource (runtime)
-- As<T>()
-  - Convert the Resource document into a strongly-typed DTO (uses runtime mapping).
-- State<T>()
-  - Read the resource state as a strongly-typed object.
-- GetLinkOrDefault(string rel)
-  - Get a single Link (or null) by relation.
-- GetLinkObjects(string rel)
-  - Get zero-or-more link objects for a relation.
-- GetEmbeddedResources<T>(string rel)
-  - Extract embedded resources as T.
-- GetResourceCollection(string rel)
-  - Get embedded resources as Resource objects.
+`ResourceBuilder` is never used as a return type in the fluent chain. All builder methods return stage interfaces.
 
-Notes
-- Serialization and deserialization use System.Text.Json (the examples use JsonSerializer).
-- The CodeGenerators package provides [HalResponse] source generator to add HAL properties to your DTOs at compile time.
+---
 
-This page is a compact reference for the methods shown in the usage guide. For more detailed examples, consult docs/usage.md and the project README.
+## 2. `IResourceCreationStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages.Resource`
+
+The root stage returned by both entry points. Exposes all top-level resource operations.
+
+```csharp
+public interface IResourceCreationStage :
+    IAddSelfLinkToResourceStage,
+    IAddLinkToResourceStage,
+    IAddCuriesLinkToResourceStage,
+    IAddEmbeddedResourceToResourceStage,
+    IBuildResource
+{
+}
+
+// Inherited members (flattened):
+IResourceLinkCreationStage  AddSelf();
+IResourceLinkCreationStage  AddLink(string rel);
+IResourceCuriesLinkCreationStage AddCuries();
+IAddResourceStage           AddEmbedded(string name);
+Resource?                   Build();
+```
+
+---
+
+## 3. `IResourceLinkCreationStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages.Resource`
+
+Returned by `AddSelf()` and `AddLink()` on the resource stage. Allows adding link objects to the current link relation, or forcing array serialization.
+
+```csharp
+public interface IResourceLinkCreationStage
+{
+    IResourceLinkObjectPropertiesSelectionStage AddLinkObject(string href);
+
+    // Force this link relation to serialize as a JSON array even when it
+    // contains only one LinkObject. Call before AddLinkObject().
+    IResourceLinkCreationStage AsArray();
+}
+```
+
+---
+
+## 4. `IResourceLinkObjectPropertiesSelectionStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages.Resource`
+
+Returned by `AddLinkObject()`. Provides all optional HAL link object properties. Also inherits re-entry points to start a new link, embedded block, or terminate the build.
+
+```csharp
+public interface IResourceLinkObjectPropertiesSelectionStage :
+    IResourceLinkCreationStage,
+    IResourceCuriesLinkCreationStage,
+    IAddSelfLinkToResourceStage,
+    IAddLinkToResourceStage,
+    IAddCuriesLinkToResourceStage,
+    IAddEmbeddedResourceToResourceStage,
+    IBuildResource
+{
+    // HAL spec §5.2 — set "templated" to true.
+    IResourceLinkObjectPropertiesSelectionStage Templated();
+
+    // HAL spec §5.3 — media type hint for the target resource.
+    IResourceLinkObjectPropertiesSelectionStage WithType(string type);
+
+    // HAL spec §5.4 — URL providing deprecation info for this link.
+    IResourceLinkObjectPropertiesSelectionStage WithDeprecationUrl(string deprecation);
+
+    // HAL spec §5.5 — secondary key when multiple links share the same relation.
+    IResourceLinkObjectPropertiesSelectionStage WithName(string name);
+
+    // HAL spec §5.6 — URI hinting at the target resource's profile.
+    IResourceLinkObjectPropertiesSelectionStage WithProfileUri(string profile);
+
+    // HAL spec §5.7 — human-readable label for the link.
+    IResourceLinkObjectPropertiesSelectionStage WithTitle(string title);
+
+    // HAL spec §5.8 — language of the target resource.
+    IResourceLinkObjectPropertiesSelectionStage WithHreflang(string hreflang);
+
+    // Force the current link object's parent link relation to serialize as a
+    // JSON array. Shadows IResourceLinkCreationStage.AsArray().
+    new IResourceLinkObjectPropertiesSelectionStage AsArray();
+
+    // Re-entry — inherited:
+    IResourceLinkCreationStage      AddSelf();
+    IResourceLinkCreationStage      AddLink(string rel);
+    IResourceCuriesLinkCreationStage AddCuries();
+    IAddResourceStage               AddEmbedded(string name);
+    Resource?                       Build();
+}
+```
+
+---
+
+## 5. `IResourceCuriesLinkCreationStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages.Resource`
+
+Returned by `AddCuries()` on the resource stage. CURIEs require both an `href` URI Template and a `name`.
+
+```csharp
+public interface IResourceCuriesLinkCreationStage
+{
+    // href must be a URI Template containing the {rel} token.
+    IResourceLinkObjectPropertiesSelectionStage AddLinkObject(string href, string name);
+
+    // Force the "curies" relation to serialize as a JSON array.
+    IResourceCuriesLinkCreationStage AsArray();
+}
+```
+
+---
+
+## 6. `IAddResourceStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages`
+
+Returned by `AddEmbedded(string name)`. Adds individual resources or a batch of resources to the named embedded slot.
+
+```csharp
+public interface IAddResourceStage
+{
+    // Add an empty embedded resource.
+    IEmbeddedResourceCreationStage AddResource();
+
+    // Add an embedded resource with a state object.
+    IEmbeddedResourceCreationStage AddResource(object? state);
+
+    // Add multiple resources from a collection, optionally building links/embedded
+    // for each via the builder callback.
+    IEmbeddedResourceCreationStage AddResources<T>(
+        IEnumerable<T> resources,
+        Action<T, IEmbeddedResourceCreationStage>? builder = null);
+}
+```
+
+---
+
+## 7. `IEmbeddedResourceCreationStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages.Embedded`
+
+The embedded-context mirror of `IResourceCreationStage`. Returned by `AddResource()` / `AddResources()`. Supports the same link, curies, and embedded operations as the root resource stage, plus `Build()` which terminates the entire chain back to the root `Resource`.
+
+```csharp
+public interface IEmbeddedResourceCreationStage :
+    IBuildHalPart<Resource>,
+    IAddSelfLinkToEmbeddedStage,
+    IAddLinkToEmbeddedStage,
+    IAddCuriesLinkToEmbeddedStage,
+    IAddResourceStage,
+    IAddEmbeddedResourceToResourceStage,
+    IBuildResource
+{
+}
+
+// Inherited members (flattened):
+IEmbeddedLinkCreationStage      AddSelf();
+IEmbeddedLinkCreationStage      AddLink(string rel);
+IEmbeddedCuriesLinkCreationStage AddCuries();
+IAddResourceStage               AddEmbedded(string name);
+IEmbeddedResourceCreationStage  AddResource();
+IEmbeddedResourceCreationStage  AddResource(object? state);
+IEmbeddedResourceCreationStage  AddResources<T>(
+                                    IEnumerable<T> resources,
+                                    Action<T, IEmbeddedResourceCreationStage>? builder = null);
+Resource?                       Build();
+```
+
+---
+
+## 8. `IEmbeddedLinkCreationStage` and `IEmbeddedLinkObjectPropertiesSelectionStage`
+
+Namespace: `Chatter.Rest.Hal.Builders.Stages.Embedded`
+
+Embedded-context mirrors of Sections 3 and 4. All property methods are identical in shape; return types are the embedded-namespace equivalents.
+
+### `IEmbeddedLinkCreationStage`
+
+```csharp
+public interface IEmbeddedLinkCreationStage
+{
+    IEmbeddedLinkObjectPropertiesSelectionStage AddLinkObject(string href);
+
+    // Force this link relation to serialize as a JSON array.
+    IEmbeddedLinkCreationStage AsArray();
+}
+```
+
+### `IEmbeddedCuriesLinkCreationStage`
+
+```csharp
+public interface IEmbeddedCuriesLinkCreationStage
+{
+    IEmbeddedLinkObjectPropertiesSelectionStage AddLinkObject(string href, string name);
+
+    // Force the "curies" relation to serialize as a JSON array.
+    IEmbeddedCuriesLinkCreationStage AsArray();
+}
+```
+
+### `IEmbeddedLinkObjectPropertiesSelectionStage`
+
+```csharp
+public interface IEmbeddedLinkObjectPropertiesSelectionStage :
+    IEmbeddedLinkCreationStage,
+    IEmbeddedCuriesLinkCreationStage,
+    IAddSelfLinkToEmbeddedStage,
+    IAddLinkToEmbeddedStage,
+    IAddCuriesLinkToEmbeddedStage,
+    IAddResourceStage,
+    IAddEmbeddedResourceToResourceStage,
+    IBuildResource
+{
+    IEmbeddedLinkObjectPropertiesSelectionStage Templated();
+    IEmbeddedLinkObjectPropertiesSelectionStage WithType(string type);
+    IEmbeddedLinkObjectPropertiesSelectionStage WithDeprecationUrl(string deprecation);
+    IEmbeddedLinkObjectPropertiesSelectionStage WithName(string name);
+    IEmbeddedLinkObjectPropertiesSelectionStage WithProfileUri(string profile);
+    IEmbeddedLinkObjectPropertiesSelectionStage WithTitle(string title);
+    IEmbeddedLinkObjectPropertiesSelectionStage WithHreflang(string hreflang);
+
+    // Shadows IEmbeddedLinkCreationStage.AsArray().
+    new IEmbeddedLinkObjectPropertiesSelectionStage AsArray();
+
+    // Re-entry — inherited:
+    IEmbeddedLinkCreationStage      AddSelf();
+    IEmbeddedLinkCreationStage      AddLink(string rel);
+    IEmbeddedCuriesLinkCreationStage AddCuries();
+    IAddResourceStage               AddEmbedded(string name);
+    IEmbeddedResourceCreationStage  AddResource();
+    IEmbeddedResourceCreationStage  AddResource(object? state);
+    IEmbeddedResourceCreationStage  AddResources<T>(
+                                        IEnumerable<T> resources,
+                                        Action<T, IEmbeddedResourceCreationStage>? builder = null);
+    Resource?                       Build();
+}
+```
+
+---
+
+## 9. `Resource` Runtime API
+
+Namespace: `Chatter.Rest.Hal`
+
+```csharp
+[JsonConverter(typeof(ResourceConverter))]
+public sealed record Resource : IHalPart
+{
+    // The normative HAL media type (HAL spec §4).
+    public const string MediaType = "application/hal+json";
+
+    // Lazily initialized; never null after first access.
+    public LinkCollection Links { get; set; }
+
+    // Lazily initialized; never null after first access.
+    public EmbeddedResourceCollection Embedded { get; set; }
+
+    // Deserialize the resource's state properties into T.
+    // Result is cached after the first successful call.
+    // Returns null if the state is absent or deserialization fails.
+    public T? State<T>() where T : class;
+
+    // Re-serialize the full Resource to a JsonNode, then deserialize
+    // the node as T. Useful for projecting a Resource into a DTO that
+    // includes _links/_embedded alongside state properties.
+    // Returns null if conversion fails.
+    public T? As<T>() where T : class;
+}
+```
+
+---
+
+## 10. `ResourceExtensions`
+
+Namespace: `Chatter.Rest.Hal`
+
+Extension methods on `Resource` for navigating links and embedded resources.
+
+```csharp
+public static class ResourceExtensions
+{
+    // Find a link by relation. Returns null if not found.
+    public static Link? GetLinkOrDefault(this Resource resource, string relation);
+
+    // Get all link objects for a relation. Returns null if the relation is not found.
+    public static LinkObjectCollection? GetLinkObjects(this Resource resource, string relation);
+
+    // Get the first link object for a relation. Returns null if not found.
+    public static LinkObject? GetLinkObjectOrDefault(this Resource resource, string linkRelation);
+
+    // Get a named link object within a relation. Returns null if not found.
+    public static LinkObject? GetLinkObjectOrDefault(this Resource resource, string linkRelation, string linkObjectName);
+
+    // Get embedded resources by name, cast to T. Returns null if the name is not found.
+    public static IEnumerable<T?>? GetEmbeddedResources<T>(this Resource resource, string name)
+        where T : class;
+
+    // Get the raw ResourceCollection for an embedded name. Returns null if not found.
+    public static ResourceCollection? GetResourceCollection(this Resource resource, string name);
+}
+```
+
+---
+
+## 11. `LinkCollectionExtensions`
+
+Namespace: `Chatter.Rest.Hal`
+
+Extension methods on `LinkCollection`.
+
+```csharp
+public static class LinkCollectionExtensions
+{
+    // Find a link by relation. Returns null if not found.
+    public static Link? GetLinkOrDefault(this LinkCollection links, string relation);
+
+    // Get all link objects for a relation. Returns null if the relation is not found.
+    public static LinkObjectCollection? GetLinkObjects(this LinkCollection links, string relation);
+
+    // Get the first link object for a relation. Returns null if not found.
+    public static LinkObject? GetLinkObjectOrDefault(this LinkCollection links, string linkRelation);
+
+    // Get a named link object within a relation. Returns null if not found.
+    public static LinkObject? GetLinkObjectOrDefault(this LinkCollection links, string linkRelation, string linkObjectName);
+
+    // Expand a CURIE relation (e.g. "acme:widgets") to its full URI using the
+    // "curies" link relation defined in this collection. Returns the original
+    // relation unchanged if no matching CURIE definition is found, the relation
+    // contains no colon, or the CURIE template lacks the {rel} token.
+    // Returns an empty string when relation is null or empty.
+    public static string ExpandCurieRelation(this LinkCollection links, string relation);
+}
+```
+
+---
+
+## 12. `LinkObjectCollectionExtensions` and `ResourceCollectionExtensions`
+
+Namespace: `Chatter.Rest.Hal`
+
+```csharp
+public static class LinkObjectCollectionExtensions
+{
+    // Get a link object by its name property. Returns null if not found.
+    public static LinkObject? GetLinkObjectOrDefault(this LinkObjectCollection linkObjects, string name);
+}
+
+public static class ResourceCollectionExtensions
+{
+    // Project each Resource in the collection to TResource via Resource.As<TResource>().
+    public static IEnumerable<TResource?> As<TResource>(this ResourceCollection rc)
+        where TResource : class;
+}
+```
+
+---
+
+## 13. `EmbeddedResourceCollectionExtensions`
+
+Namespace: `Chatter.Rest.Hal`
+
+Extension methods on `EmbeddedResourceCollection`.
+
+```csharp
+public static class EmbeddedResourceCollectionExtensions
+{
+    // Get the EmbeddedResource entry for a given name. Returns null if not found.
+    public static EmbeddedResource? GetEmbeddedResource(this EmbeddedResourceCollection erc, string name);
+
+    // Get the ResourceCollection for a given embedded name. Returns null if not found.
+    public static ResourceCollection? GetResourceCollection(this EmbeddedResourceCollection erc, string name);
+
+    // Get embedded resources by name, cast to T. Returns null if not found.
+    public static IEnumerable<T?>? GetResources<T>(this EmbeddedResourceCollection erc, string name)
+        where T : class;
+}
+```
+
+---
+
+## 14. Serialization API
+
+### `HalJsonOptions`
+
+Namespace: `Chatter.Rest.Hal`
+
+```csharp
+public sealed class HalJsonOptions
+{
+    // Process-global singleton consumed by attribute-wired converters.
+    // Mutate only at application startup, before any serialization occurs.
+    public static readonly HalJsonOptions Default;
+
+    // When true, all link relations serialize as JSON arrays regardless of
+    // how many LinkObjects they contain. Aligns with HAL spec guidance:
+    // "If you're unsure whether the link should be singular, assume multiple."
+    // Default: false (preserves existing library behavior).
+    public bool AlwaysUseArrayForLinks { get; set; }
+}
+```
+
+### `JsonSerializerOptionsExtensions`
+
+Namespace: `Chatter.Rest.Hal.Extensions`
+
+```csharp
+public static class JsonSerializerOptionsExtensions
+{
+    // Register all HAL JSON converters with the given JsonSerializerOptions.
+    // Options-registered converters take precedence over [JsonConverter] attribute
+    // converters when the options instance is supplied to JsonSerializer.
+    // Safe to call multiple times — duplicate registration is suppressed.
+    public static JsonSerializerOptions AddHalConverters(
+        this JsonSerializerOptions options,
+        HalJsonOptions? halOptions = null);
+}
+```
+
+**Usage:**
+
+```csharp
+var options = new JsonSerializerOptions();
+options.AddHalConverters();                             // default options
+options.AddHalConverters(new HalJsonOptions { AlwaysUseArrayForLinks = true });
+```
+
+To use `AlwaysUseArrayForLinks` globally via attribute-wired converters (without passing options to every serializer call):
+
+```csharp
+// At application startup only:
+HalJsonOptions.Default.AlwaysUseArrayForLinks = true;
+```
+
+---
+
+## 15. Source Generator: `[HalResponse]`
+
+### Attribute
+
+Package: `Chatter.Rest.Hal.Core`
+Namespace: `Chatter.Rest.Hal`
+
+```csharp
+[AttributeUsage(AttributeTargets.Class)]
+public class HalResponseAttribute : Attribute { }
+```
+
+### Generator
+
+Package: `Chatter.Rest.Hal.CodeGenerators` (analyzer; referenced as `<PackageReference>` with `OutputItemType="Analyzer"`)
+
+### Constraints on the decorated class
+
+- Must be `partial`
+- Must be non-generic
+- Must be non-nested
+
+### Generated output
+
+The generator adds the following members to the partial class at compile time:
+
+```csharp
+[JsonPropertyName("_links")]
+public LinkCollection? Links { get; set; }
+
+[JsonPropertyName("_embedded")]
+public EmbeddedResourceCollection? Embedded { get; set; }
+```
+
+### Example
+
+```csharp
+// Declaration (consumer code):
+[HalResponse]
+public partial class OrderResponse
+{
+    public int Id { get; set; }
+    public string Status { get; set; }
+}
+
+// Generated (compile-time, not written to disk):
+public partial class OrderResponse
+{
+    [JsonPropertyName("_links")]
+    public LinkCollection? Links { get; set; }
+
+    [JsonPropertyName("_embedded")]
+    public EmbeddedResourceCollection? Embedded { get; set; }
+}
+```

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,427 @@
+# Chatter.Rest.Hal — Technical Architecture Reference
+
+This document is a technical reference for contributors and AI agents. It describes the internal structure, contracts, and behavioral invariants of the library. For the HAL specification itself, see [CLAUDE.md](../CLAUDE.md) and the [HAL draft RFC](https://datatracker.ietf.org/doc/html/draft-kelly-json-hal).
+
+---
+
+## Section 1 — Domain Model
+
+All eight domain types are `sealed record` implementing the `IHalPart` marker interface. Every type is annotated with `[JsonConverter(typeof(XConverter))]` to wire up its custom serializer.
+
+### `Resource`
+
+```csharp
+public sealed record Resource : IHalPart
+{
+    public const string MediaType = "application/hal+json";
+
+    public Resource() { }
+    public Resource(object? state);
+
+    public LinkCollection Links { get; set; }
+    public EmbeddedResourceCollection Embedded { get; set; }
+
+    public T? State<T>() where T : class;
+    public T? As<T>() where T : class;
+}
+```
+
+- `State<T>()` — returns the resource state as `T`. If the underlying state is a `JsonElement`, it deserializes it on first call and caches the result. If state is a `JsonObject` (from the deserialization path), it calls the lazy `_stateCreator` delegate. Returns `null` on failure rather than throwing.
+- `As<T>()` — serializes the entire `Resource` to a `JsonNode` (if not already cached in `_resourceNode`) then deserializes that node to `T`. Use this to round-trip a HAL response into a typed DTO that includes `_links`/`_embedded` properties.
+- **Lazy init via `Func<T>` delegates** — the internal deserialization constructor (`internal Resource(JsonNode?, Func<JsonObject?>, Func<LinkCollection?>, Func<EmbeddedResourceCollection?>)`) stores the three factory delegates. `Links` and `Embedded` property getters invoke these delegates on first access and cache the result, making deserialization allocation-lazy.
+- `StateObject` — internal property that drives `ResourceConverter.Write`. Its getter calls `State<object>()`.
+
+### `Link`
+
+```csharp
+public sealed record Link : IHalPart
+{
+    public Link(string rel);      // throws ArgumentNullException if null/whitespace
+
+    public string Rel { get; }
+    public LinkObjectCollection LinkObjects { get; set; }
+    public bool IsArray { get; set; }
+}
+```
+
+- `IsArray` — when `true`, this relation serializes as a JSON array regardless of how many `LinkObject` entries it contains. Set by `LinkBuilder.SetIsArray()` via the builder API, or set to `true` by `LinkCollectionConverter.Read` when the JSON value is a JSON array.
+
+### `LinkObject`
+
+```csharp
+public sealed record LinkObject : IHalPart
+{
+    public LinkObject(string href);   // throws ArgumentNullException if null/whitespace
+
+    public string Href { get; }           // REQUIRED
+    public bool? Templated { get; set; }  // OPTIONAL
+    public string? Type { get; set; }     // OPTIONAL
+    public string? Deprecation { get; set; } // OPTIONAL
+    public string? Name { get; set; }     // OPTIONAL
+    public string? Profile { get; set; }  // OPTIONAL
+    public string? Title { get; set; }    // OPTIONAL
+    public string? Hreflang { get; set; } // OPTIONAL
+}
+```
+
+All properties except `Href` are optional per the HAL specification.
+
+### `EmbeddedResource`
+
+```csharp
+public sealed record EmbeddedResource : IHalPart
+{
+    public EmbeddedResource(string name);  // throws ArgumentException if null/whitespace
+
+    public string Name { get; }
+    public ResourceCollection Resources { get; set; }
+    public bool ForceWriteAsCollection { get; set; }
+}
+```
+
+- `ForceWriteAsCollection` — overrides the default count-based write behavior. When `true`, the converter always writes an array even if `Resources` contains only one element.
+
+### Collection Types
+
+| Type | Implements | Serialized as |
+|---|---|---|
+| `LinkCollection` | `ICollection<Link>, IHalPart` | `_links` object |
+| `LinkObjectCollection` | `ICollection<LinkObject>, IHalPart` | array or object within a link relation |
+| `EmbeddedResourceCollection` | `ICollection<EmbeddedResource>, IHalPart` | `_embedded` object |
+| `ResourceCollection` | `ICollection<Resource>, IHalPart` | array of resource objects |
+
+Each collection wraps an internal `Collection<T>` and delegates all `ICollection<T>` operations to it. Each carries a `[JsonConverter]` attribute wiring to its own converter.
+
+### Containment Diagram
+
+```
+Resource
+├── LinkCollection (_links)
+│   └── Link[]
+│       ├── Rel: string
+│       ├── IsArray: bool
+│       └── LinkObjectCollection
+│           └── LinkObject[]
+│               ├── Href (required)
+│               └── Templated, Type, Deprecation, Name, Profile, Title, Hreflang (optional)
+└── EmbeddedResourceCollection (_embedded)
+    └── EmbeddedResource[]
+        ├── Name: string
+        ├── ForceWriteAsCollection: bool
+        └── ResourceCollection
+            └── Resource[]  (recursive)
+```
+
+---
+
+## Section 2 — Staged Builder Pattern
+
+The builder uses a staged interface pattern: each method returns an interface exposing only the operations valid at that point. This enforces correct construction order at compile time.
+
+### Entry Points
+
+```csharp
+ResourceBuilder.New() -> IResourceCreationStage
+ResourceBuilder.WithState(object state) -> IResourceCreationStage
+```
+
+Both create a `ResourceBuilder` with `parent = null`, making it the root of the chain.
+
+### Abstract Base: `HalBuilder<THalPart>`
+
+```csharp
+public abstract class HalBuilder<THalPart> : IBuildResource, IBuildHalPart<THalPart>
+    where THalPart : class, IHalPart
+{
+    public HalBuilder(IBuildHalPart<IHalPart>? parent);
+    public IBuildHalPart<IHalPart>? Parent { get; }
+
+    public IBuildHalPart<TParent>? FindParent<TParent>() where TParent : class, IHalPart;
+    public IBuildHalPart<IHalPart> FindRoot();
+    protected bool IsRoot();
+
+    public abstract THalPart BuildPart();
+    public Resource? Build();
+}
+```
+
+- `FindParent<TParent>()` — walks the `Parent` chain upward, returning the first builder that implements `IBuildHalPart<TParent>`. Used by `LinkObjectBuilder.AsArray()` to find the enclosing `LinkBuilder` without coupling tightly to the chain shape.
+- `FindRoot()` — walks to the top of the chain (where `Parent == null`).
+- `Build()` — calls `FindRoot()`, casts to `IBuildHalPart<Resource>`, and calls `BuildPart()`. Available at every stage via `IBuildResource`.
+
+### Builder Class Map
+
+| Builder Class | Produces | Key notes |
+|---|---|---|
+| `ResourceBuilder` | `Resource` | Root builder; holds `LinkCollectionBuilder` and `EmbeddedResourceCollectionBuilder` |
+| `LinkCollectionBuilder` | `LinkCollection` | Creates `LinkBuilder` instances for each relation |
+| `LinkBuilder` | `Link` | Holds `_isArray`; exposes `SetIsArray()` (called by `LinkObjectBuilder.AsArray()`) |
+| `LinkObjectCollectionBuilder` | `LinkObjectCollection` | Creates `LinkObjectBuilder` instances |
+| `LinkObjectBuilder` | `LinkObject` | `AsArray()` navigates to enclosing `LinkBuilder` via `FindParent<Link>()` |
+| `EmbeddedResourceCollectionBuilder` | `EmbeddedResourceCollection` | Creates `EmbeddedResourceBuilder` instances |
+| `EmbeddedResourceBuilder` | `EmbeddedResource` | Delegates to `ResourceCollectionBuilder` |
+| `ResourceCollectionBuilder` | `ResourceCollection` | Creates nested `ResourceBuilder` instances |
+
+### Stage Interface Hierarchy
+
+Stages live in two parallel namespaces: `Builders.Stages.Resource` and `Builders.Stages.Embedded`. This dual-namespace pattern means the same logical operation (e.g., "add a link object") returns a different interface type depending on whether you are building a top-level resource or an embedded resource — preserving the correct stage context for IntelliSense and compile-time safety.
+
+**Resource namespace (`Builders.Stages.Resource`)**
+
+| Interface | Key members |
+|---|---|
+| `IResourceCreationStage` | Extends `IAddLinkToResourceStage`, `IAddSelfLinkToResourceStage`, `IAddCuriesLinkToResourceStage`, `IAddEmbeddedResourceToResourceStage`, `IBuildResource` |
+| `IResourceLinkCreationStage` | `AddLinkObject(string href)`, `AsArray()` |
+| `IResourceLinkObjectPropertiesSelectionStage` | `AsArray()`, `Templated()`, `WithType()`, `WithDeprecationUrl()`, `WithName()`, `WithProfileUri()`, `WithTitle()`, `WithHreflang()` |
+| `IResourceCuriesLinkCreationStage` | `AddLinkObject(string href, string name)`, `AsArray()` |
+| `IAddLinkToResourceStage` | `AddLink(string rel) -> IResourceLinkCreationStage` |
+| `IAddSelfLinkToResourceStage` | `AddSelf() -> IResourceLinkCreationStage` |
+| `IAddCuriesLinkToResourceStage` | `AddCuries() -> IResourceCuriesLinkCreationStage` |
+
+**Embedded namespace (`Builders.Stages.Embedded`)**
+
+Mirrors the Resource namespace exactly, but each operation returns the `IEmbedded*` variant of the stage interface.
+
+**Shared stages**
+
+| Interface | Key members |
+|---|---|
+| `IAddResourceStage` | `AddResource()`, `AddResource(object? state)`, `AddResources<T>(IEnumerable<T>, Action<T, IEmbeddedResourceCreationStage>?)` |
+| `IBuildResource` | `Build() -> Resource?` — available at every leaf stage |
+
+### `AsArray()` Propagation
+
+`AsArray()` is available in two contexts:
+
+1. **After `AddLink`/`AddSelf`/`AddCuries`** — on the link creation stage (e.g., `IResourceLinkCreationStage`). Calls `LinkBuilder.AsArray()` directly, setting `_isArray = true` on that builder.
+2. **After `AddLinkObject`** — on the link object properties stage (e.g., `IResourceLinkObjectPropertiesSelectionStage`). `LinkObjectBuilder.AsArray()` calls `FindParent<Link>()` which returns the enclosing `LinkBuilder`, then calls `LinkBuilder.SetIsArray()`.
+
+Both paths ultimately set `Link.IsArray = true` when `BuildPart()` is called on the `LinkBuilder`.
+
+### Call-Chain Flow Example
+
+```
+ResourceBuilder.WithState(myDto)         // returns IResourceCreationStage
+  .AddSelf()                             // returns IResourceLinkCreationStage
+  .AddLinkObject("/api/orders/123")      // returns IResourceLinkObjectPropertiesSelectionStage
+  .Build()                               // walks to root ResourceBuilder, calls BuildPart()
+                                         // -> Resource { State=myDto, Links=[self->/api/orders/123] }
+```
+
+Each step returns a narrower interface. `Build()` is always available because every stage extends `IBuildResource`.
+
+---
+
+## Section 3 — Converter Architecture
+
+**Namespace:** `Chatter.Rest.Hal.Converters`
+
+### Wire-Up
+
+Every domain type carries `[JsonConverter(typeof(XConverter))]`. These attribute-wired converters are used automatically when `JsonSerializer` operates without custom `JsonSerializerOptions`.
+
+**Alternative explicit registration** via `AddHalConverters`:
+
+```csharp
+// JsonSerializerOptionsExtensions
+public static JsonSerializerOptions AddHalConverters(
+    this JsonSerializerOptions options,
+    HalJsonOptions? halOptions = null)
+```
+
+This registers all 8 converters on the `JsonSerializerOptions` instance. A duplicate-guard checks for an existing `LinkCollectionConverter` before registering; calling `AddHalConverters` multiple times on the same instance is safe. Options-registered converters take precedence over attribute-wired converters when those options are supplied to the serializer.
+
+### `HalJsonOptions`
+
+```csharp
+public sealed class HalJsonOptions
+{
+    public static readonly HalJsonOptions Default = new();
+    public bool AlwaysUseArrayForLinks { get; set; } = false;
+}
+```
+
+`HalJsonOptions.Default` is a process-global singleton. Mutate only at application startup before any serialization occurs.
+
+### `HalJsonOptions`-Aware Converters
+
+Three converters accept an optional `HalJsonOptions` constructor parameter and fall back to `HalJsonOptions.Default` when none is provided:
+
+| Converter | Options-aware |
+|---|---|
+| `LinkCollectionConverter` | Yes — `(HalJsonOptions? halJsonOptions)` ctor |
+| `LinkConverter` | Yes — `(HalJsonOptions? halJsonOptions)` ctor |
+| `LinkObjectCollectionConverter` | Yes — `(HalJsonOptions? halJsonOptions)` ctor |
+
+### Non-Options Converters
+
+| Converter | Notes |
+|---|---|
+| `LinkObjectConverter` | Standard property-by-property read/write |
+| `ResourceConverter` | Separates state from `_links`/`_embedded` |
+| `EmbeddedResourceCollectionConverter` | Dispatches on object vs. array per entry |
+| `EmbeddedResourceConverter` | Wraps read/write of a single embedded entry |
+| `ResourceCollectionConverter` | Reads/writes arrays of `Resource` |
+
+### Write Behavior
+
+**`LinkCollectionConverter.Write`**
+
+Iterates links. For each link, evaluates:
+
+```csharp
+bool forceArray = (_halJsonOptions ?? HalJsonOptions.Default).AlwaysUseArrayForLinks || link.IsArray;
+```
+
+- If `forceArray` is `false` and `link.LinkObjects.Count == 1`, writes the single `LinkObject` as a JSON object.
+- Otherwise writes a JSON array of all `LinkObject` entries.
+
+**`LinkObjectCollectionConverter.Write`**
+
+Evaluates only `HalJsonOptions.AlwaysUseArrayForLinks` (no access to `Link.IsArray` at this level). This converter is invoked when `LinkObjectCollection` is serialized directly rather than through `LinkCollectionConverter`.
+
+**`EmbeddedResourceCollectionConverter.Write`**
+
+For each `EmbeddedResource`, evaluates:
+
+```csharp
+if (embeddedvalue.Resources.Count == 1 && !embeddedvalue.ForceWriteAsCollection)
+```
+
+- `true` → writes the single `Resource` as a JSON object.
+- `false` → writes all resources as a JSON array.
+
+**`ResourceConverter.Write`**
+
+1. Serializes `StateObject` to a `JsonNode`.
+2. Iterates the node's properties, skipping any named `Links` or `Embedded`.
+3. Writes each remaining state property directly to the JSON writer.
+4. If `Links` is non-null and non-empty, writes `"_links"` followed by the serialized `LinkCollection`.
+5. If `Embedded` is non-null and non-empty, writes `"_embedded"` followed by the serialized `EmbeddedResourceCollection`.
+
+State properties are always emitted before `_links` and `_embedded`.
+
+### Read Behavior
+
+**`ResourceConverter.Read`**
+
+Parses the entire JSON token into a `JsonNode`. Constructs three lazy `Func<T>` delegates:
+
+- `stateCreator` — clones the node, removes `_links` and `_embedded`, returns the remaining `JsonObject`.
+- `linksCreator` — deserializes `node["_links"]` as `LinkCollection`.
+- `embeddedCreator` — deserializes `node["_embedded"]` as `EmbeddedResourceCollection`.
+
+These delegates are passed to the internal `Resource` constructor and invoked only when the corresponding property is first accessed.
+
+**`LinkCollectionConverter.Read`**
+
+Handles three JSON shapes per link relation:
+
+- **Object** (`"rel": { "href": "..." }`) — deserializes as a single `LinkObject`.
+- **Array** (`"rel": [{ "href": "..." }]`) — deserializes as `LinkObjectCollection` and sets `link.IsArray = true`.
+- **String shorthand** (`"rel": "/path"`) — constructs a `LinkObject` directly from the string value.
+- **Null** (`"rel": null`) — adds the `Link` with an empty `LinkObjectCollection`.
+
+**`LinkConverter.Read`**
+
+Expects a single-property JSON object where the key is the relation name. Returns `null` (tolerant) if:
+- Input is not a `JsonObject`.
+- The object does not have exactly one property.
+- The relation key is null or whitespace.
+- The value is an object without a valid `href`.
+
+**`EmbeddedResourceCollectionConverter.Read`**
+
+For each key in the `_embedded` object, dispatches:
+- **JsonObject** → deserializes as a single `Resource`, adds to `embedded.Resources`.
+- **JsonArray** → deserializes as `ResourceCollection`, assigns to `embedded.Resources`.
+- Other/null → creates `EmbeddedResource` with empty `Resources`.
+
+---
+
+## Section 4 — Source Generator Pipeline
+
+The generator lives in `Chatter.Rest.Hal.CodeGenerators` and consists of three files.
+
+### `HalResponseGenerator` — Entry Point
+
+```csharp
+[Generator]
+public class HalResponseGenerator : IIncrementalGenerator
+{
+    public void Initialize(IncrementalGeneratorInitializationContext context);
+}
+```
+
+Registers a `SyntaxProvider.CreateSyntaxProvider` pipeline:
+
+1. **Syntax filter**: `Parser.IsSyntaxTargetForGeneration` — fast check, runs on every syntax node.
+2. **Semantic filter**: `Parser.GetSemanticTargetForGeneration` — resolves the attribute symbol.
+3. Results are collected via `.Collect()` and forwarded to `Emitter.Emit`.
+
+### `Parser` — Filter Stage
+
+**Syntax filter** (`IsSyntaxTargetForGeneration`): matches any `AttributeSyntax` whose name resolves to `"HalResponse"` or `"HalResponseAttribute"` (unqualified, to handle both forms).
+
+**Semantic filter** (`GetSemanticTargetForGeneration`): resolves the attribute's constructor symbol, checks `ContainingType.ToDisplayString() == "Chatter.Rest.Hal.HalResponseAttribute"`. On match, returns the nearest enclosing `ClassDeclarationSyntax` by walking `attributeSyntax.Ancestors()`.
+
+### `Emitter` — Code Generation Stage
+
+Deduplicates by `(Namespace, Name)` pair (handles partial classes and multiple attributes on the same class). For each unique class, generates a `partial class` with two properties:
+
+```csharp
+// Generated output shape
+namespace MyApp
+{
+    partial class MyResponse
+    {
+        [JsonPropertyName("_links")]
+        public LinkCollection? Links { get; set; }
+
+        [JsonPropertyName("_embedded")]
+        public EmbeddedResourceCollection? Embedded { get; set; }
+    }
+}
+```
+
+Output file name: `{Namespace}.{ClassName}.g.cs`.
+
+### Known Limitations
+
+- **Non-generic classes only** — `ClassDeclarationSyntax` is returned without generic parameter handling; generic classes are not supported.
+- **Non-nested classes only** — `GetNamespaceFrom` walks ancestors looking for `NamespaceDeclarationSyntax` or `FileScopedNamespaceDeclarationSyntax`. Classes nested inside other classes produce incorrect namespace resolution.
+- **Attribute location** — `[HalResponse]` is defined in `Chatter.Rest.Hal.Core`, not in the generator assembly. Consumer projects reference `Chatter.Rest.Hal.Core` at runtime and the generator assembly with `PrivateAssets="all"`.
+
+---
+
+## Section 5 — Package and Project Relationships
+
+```
+Chatter.Rest.Hal.sln
+├── src/
+│   ├── Chatter.Rest.Hal/            # Core library
+│   │   ├── depends on: System.Text.Json (inbox on net8.0, NuGet on netstandard2.0)
+│   │   └── NuGet: Chatter.Rest.Hal v0.9.2
+│   │
+│   ├── Chatter.Rest.Hal.Core/       # Shared attribute
+│   │   ├── contains: HalResponseAttribute only
+│   │   ├── referenced at runtime by consumer projects
+│   │   └── NuGet: referenced transitively by consumers
+│   │
+│   └── Chatter.Rest.Hal.CodeGenerators/   # Roslyn source generator
+│       ├── references: Chatter.Rest.Hal.Core
+│       ├── consumers add: <PackageReference ... PrivateAssets="all" />
+│       └── NuGet: Chatter.Rest.Hal.CodeGenerators v0.2.5
+│
+└── test/
+    ├── Chatter.Rest.Hal.Tests/                   # Tests for core library
+    └── Chatter.Rest.Hal.CodeGenerators.Tests/    # Tests for source generator
+```
+
+### Package Responsibilities
+
+**`Chatter.Rest.Hal`** — the core library. Provides all domain types, fluent builder API, JSON converters, and query extension methods. Has no dependencies outside `System.Text.Json`. Consumers reference this package to build and consume HAL documents.
+
+**`Chatter.Rest.Hal.Core`** — ships only `HalResponseAttribute`. Exists as a separate package so consumer projects can reference the attribute at runtime without taking a dependency on the Roslyn analyzer assembly.
+
+**`Chatter.Rest.Hal.CodeGenerators`** — the Roslyn incremental source generator. References `Chatter.Rest.Hal.Core` to access `HalResponseAttribute` during compilation. Consumers add it as a build-time-only reference (`PrivateAssets="all"`), meaning it does not appear in the consumer's published output or transitive dependency graph.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,76 +1,141 @@
-Development — Local setup, tests, and code generation
+# Development Guide
 
-Purpose
+Local setup, build commands, test conventions, and CI/CD parity for Chatter.Rest.Hal.
 
-This document explains the developer workflows used in this repository: how to set up a local environment, run builds and tests, and run the code generator(s). It's written for new contributors who want to iterate on code and verify changes locally.
+---
 
-Prerequisites
+## 1. Prerequisites
 
-- Install the .NET SDK version referenced by global.json in the repository root. Use the SDK that matches that file to avoid compatibility issues.
-- A modern code editor or IDE (Visual Studio, VS Code, Rider) with C# tooling is recommended.
-- Git for cloning and branching.
+- **.NET 8.0 SDK** (`8.0.x`) — the version used in CI workflows
+- **Language:** C# 10.0 (set per project via `<LangVersion>10.0</LangVersion>`)
+- No external tools beyond the .NET SDK are required
 
-Repository layout (high-level)
+There is no `global.json` in this repository. The SDK version is pinned only in CI. Use any `8.0.x` SDK locally.
 
-- src/ — main source projects
-- test/ — unit and integration tests
-- docs/ — repository documentation (this file)
-- generator or tools/ (if present) — code-generation tool projects
+---
 
-Note: exact directory names may vary; search the repo for project names or for a generator-related project if you are unsure.
+## 2. Solution Structure
 
-Common development workflows
+```
+Chatter.Rest.Hal.sln
+├── src/
+│   ├── Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
+│   ├── Chatter.Rest.Hal.Core/Chatter.Rest.Hal.Core.csproj
+│   └── Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj
+└── test/
+    ├── Chatter.Rest.Hal.Tests/Chatter.Rest.Hal.Tests.csproj
+    └── Chatter.Rest.Hal.CodeGenerators.Tests/Chatter.Rest.Hal.CodeGenerators.Tests.csproj
+```
 
-1) Build and run tests
+**Target frameworks:**
 
-Outcome: you will verify that the solution builds and that all tests pass locally.
-What to do (outcome-focused):
-- Restore dependencies and build the solution using your .NET tooling.
-- Execute the test suites (unit tests first; integration tests as needed).
-- Fix any failing tests or open an issue if a failing test represents an unrelated CI/regression problem.
+- `src/` projects multi-target `net8.0;netstandard2.0`
+- `test/` projects target `net8.0` only
 
-What to expect:
-- A clean build and passing tests should match CI results. If tests fail locally but pass in CI, confirm SDK versions and environmental differences.
+---
 
-2) Running the code generator (high-level)
+## 3. Build Commands
 
-Outcome: regenerate generated artifacts used by the project (models, clients, or other assets produced by a generator).
+```bash
+# Restore dependencies
+dotnet restore
 
-How to proceed (conceptual steps):
-- Identify the generator project in the repository (commonly found under a tools/ or src/ directory). The project name or README often indicates it is the generator.
-- Build the generator project with the same .NET SDK used for the main solution.
-- Run the generator with the expected input files (e.g., schema, templates, or configuration). The generator usually accepts input path(s) and an output directory. When in doubt, open the generator project's README or source code to confirm expected arguments.
-- Inspect the generated output and add the regenerated files to your branch if your change requires updated generated code.
+# Build (Debug)
+dotnet build
 
-Notes and best practices:
-- Prefer regenerating outputs locally and including the results in the same PR when changing inputs that affect generated files. This keeps CI reproducible and reviewers able to verify the final state.
-- If generated code is large, consider including only the meaningful diffs or explain why generated output is excluded.
+# Build (Release, skip restore)
+dotnet build -c Release --no-restore
+```
 
-3) Debugging and iterative development
+---
 
-Outcome: quickly iterate on a change with fast feedback.
+## 4. Test Commands
 
-What to do:
-- Use your IDE debugger to step through code and tests.
-- Add focused unit tests to reproduce bugs before implementing fixes.
-- Keep iterations small; run relevant tests frequently rather than the entire suite on every change.
+```bash
+# Run core library tests
+dotnet test test/Chatter.Rest.Hal.Tests/Chatter.Rest.Hal.Tests.csproj
 
-Troubleshooting tips
+# Run code generator tests
+dotnet test test/Chatter.Rest.Hal.CodeGenerators.Tests/Chatter.Rest.Hal.CodeGenerators.Tests.csproj
 
-- SDK mismatch: If build/test failures indicate SDK differences, confirm the version in global.json and install that SDK.
-- Missing tools: If the generator requires an external tool or NuGet package, the generator project's README should list them. Install or restore as instructed.
-- Environmental differences: CI may run with different environment variables or OS constraints. When behavior diverges, capture logs and open an issue with reproduction steps.
+# Run all tests
+dotnet test
+```
 
-What to include in a development PR
+CI runs tests with `-c Release --no-build` after a Release build step. To replicate CI exactly:
 
-- A short summary of the change and why it was made.
-- Steps you followed to validate the change locally (build, test, generate outputs).
-- Any files that were regenerated as part of the change, or explicit instructions to regenerate them.
-- Notes on compatibility or versioning if the change affects public APIs or generated artifacts.
+```bash
+dotnet build -c Release --no-restore
+dotnet test test/Chatter.Rest.Hal.Tests/Chatter.Rest.Hal.Tests.csproj -c Release --no-build
+dotnet test test/Chatter.Rest.Hal.CodeGenerators.Tests/Chatter.Rest.Hal.CodeGenerators.Tests.csproj -c Release --no-build
+```
 
-Further reading and reference
+---
 
-- See CONTRIBUTING.md for repository-level contribution expectations and PR guidance.
-- The repository's README may hold additional high-level info.
+## 5. NuGet Packaging
 
-If something in these docs is unclear or missing, please open an issue titled "docs: clarify development workflow" and describe what you'd like to see.
+```bash
+dotnet pack src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj -c Release -o publish/nuget
+dotnet pack src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj -c Release -o publish/nuget
+```
+
+Output packages land in `publish/nuget/`.
+
+---
+
+## 6. CI/CD Parity
+
+Two workflows live in `.github/workflows/`:
+
+| Workflow | Scope |
+|---|---|
+| `hal-cicd.yml` | `src/Chatter.Rest.Hal/`, `test/Chatter.Rest.Hal.Tests/` |
+| `codegen-cicd.yml` | `src/Chatter.Rest.Hal.CodeGenerators/`, `test/Chatter.Rest.Hal.CodeGenerators.Tests/` |
+
+**Both workflows:**
+
+- Trigger on pushes to `feature/**` branches (path-scoped to their respective `src/` and `test/` directories) and on pushes to `main`
+- Also trigger on pull requests targeting `main` (path-scoped)
+- Use `dotnet restore --locked-mode` — requires `packages.lock.json` to be present and current
+- Build with `-c Release --no-restore`
+- Test with `-c Release --no-build`
+- Deploy to NuGet.org only when `github.ref == 'refs/heads/main'` (after a successful PR merge) via the `NUGET_API_KEY_CHATTER_HAL` secret
+
+**Lock file troubleshooting:** If `dotnet restore --locked-mode` fails locally with lock file errors, delete `packages.lock.json` and run `dotnet restore` to regenerate it. Commit the regenerated file.
+
+---
+
+## 7. Source Generator: No Manual Invocation
+
+The Roslyn source generator (`Chatter.Rest.Hal.CodeGenerators`) runs automatically during `dotnet build`. No explicit invocation is required.
+
+To inspect generated output after a build:
+
+```
+obj/Debug/net8.0/generated/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.HalResponseGenerator/
+```
+
+---
+
+## 8. Code Style
+
+`.editorconfig` enforces:
+
+- **Line endings:** CRLF
+- **Indentation:** tabs
+- **Braces:** Allman style (`csharp_new_line_before_open_brace=all`)
+- **Namespaces:** file-scoped (silent preference)
+
+All projects have `<Nullable>enable</Nullable>`. The `netstandard2.0` target of converter files produces pre-existing `CS8604`/`CS8603` nullable warnings — these are baseline noise and do not affect the `net8.0` build. Do not treat them as regressions.
+
+---
+
+## 9. Test Conventions
+
+- **Framework:** xunit 2.4.x
+- **Assertions:** FluentAssertions 6.x (preferred); xunit `Assert` also used
+- **Mocking:** Moq 4.x (core library tests only)
+- **Coverage:** coverlet
+- **Test naming:** `Method_Scenario_Expected` — e.g., `Curies_Are_Parsed_As_Array_Of_LinkObjects`
+- **JSON fixtures:** `test/Chatter.Rest.Hal.Tests/Json/` — loaded via `TestHelpers.LoadResourceFromFixture()`
+- **Shared helpers:** `TestHelpers` provides factory methods (`CreateLink`, `CreateLinkObject`, `CreateResourceWithLink`) and JSON assertion utilities

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -1,0 +1,313 @@
+# Chatter.Rest.Hal — Serialization Reference
+
+This document is a deep-dive reference for how `Chatter.Rest.Hal` serializes and deserializes HAL JSON documents. It covers converter wiring, configuration, force-array behavior, deserialization internals, and media type usage.
+
+---
+
+## 1. Two Serialization Paths
+
+There are two ways converters are wired to domain types.
+
+### 1.1 Attribute-wired (default)
+
+Every domain type carries a `[JsonConverter(typeof(XConverter))]` attribute:
+
+```csharp
+[JsonConverter(typeof(ResourceConverter))]
+public sealed record Resource : IHalPart { ... }
+
+[JsonConverter(typeof(LinkCollectionConverter))]
+public sealed record LinkCollection : ICollection<Link>, IHalPart { ... }
+```
+
+This means any call to `JsonSerializer.Serialize` / `JsonSerializer.Deserialize` works with no extra configuration — the runtime resolves the converter from the attribute automatically.
+
+### 1.2 Explicit via `AddHalConverters()`
+
+Call `options.AddHalConverters(halOptions?)` to register all eight converters on a specific `JsonSerializerOptions` instance:
+
+```csharp
+var options = new JsonSerializerOptions();
+options.AddHalConverters();
+```
+
+Converters registered on `JsonSerializerOptions.Converters` take **precedence** over attribute-wired converters when those options are supplied to the serializer. This is the mechanism that makes per-options `HalJsonOptions` work — the converters are constructed with the specific `HalJsonOptions` instance at registration time.
+
+Use this path when:
+- You need per-options-instance `HalJsonOptions` configuration (e.g., different link array behavior per endpoint).
+- You are integrating with ASP.NET Core's serializer pipeline (see Section 3).
+
+When you never call `AddHalConverters()`, attribute-wired converters remain in effect and read `HalJsonOptions.Default` at write time.
+
+---
+
+## 2. `HalJsonOptions`
+
+```csharp
+// Chatter.Rest.Hal namespace
+public sealed class HalJsonOptions
+{
+    public static readonly HalJsonOptions Default;
+    public bool AlwaysUseArrayForLinks { get; set; } // default: false
+}
+```
+
+### `Default`
+
+`HalJsonOptions.Default` is a process-global singleton instance. Attribute-wired converters resolve options from this instance at write time (not at construction time), so mutations to `Default` affect all subsequent serializations that use attribute-wired converters.
+
+**Mutate only at application startup, before any serialization occurs.** `bool` reads and writes are atomic on all .NET platforms, so no locking is required as long as mutations are confined to startup.
+
+### `AlwaysUseArrayForLinks`
+
+When `false` (the default), a link relation with a single `LinkObject` serializes as a JSON object. When `true`, all link relations serialize as JSON arrays regardless of count. This aligns with HAL spec guidance:
+
+> "If you're unsure whether the link should be singular, assume it will be multiple."
+
+**Warning:** Mutating `HalJsonOptions.Default.AlwaysUseArrayForLinks` after the application has started handling concurrent requests creates a race condition. Use a per-options instance via `AddHalConverters(new HalJsonOptions { ... })` if you need different behavior for different serialization contexts.
+
+---
+
+## 3. `AddHalConverters()`
+
+```csharp
+// Chatter.Rest.Hal.Extensions namespace
+public static JsonSerializerOptions AddHalConverters(
+    this JsonSerializerOptions options,
+    HalJsonOptions? halOptions = null)
+```
+
+### Registration order
+
+Converters are added to `options.Converters` in this order:
+
+1. `LinkCollectionConverter(resolved)`
+2. `LinkObjectCollectionConverter(resolved)`
+3. `LinkConverter(resolved)`
+4. `LinkObjectConverter()`
+5. `ResourceConverter()`
+6. `EmbeddedResourceCollectionConverter()`
+7. `EmbeddedResourceConverter()`
+8. `ResourceCollectionConverter()`
+
+Where `resolved` is `halOptions ?? HalJsonOptions.Default`.
+
+### Idempotency
+
+The method checks `options.Converters.OfType<LinkCollectionConverter>().Any()` before adding converters. Calling `AddHalConverters()` more than once on the same options instance is safe and a no-op after the first call.
+
+### Options resolution
+
+`halOptions ?? HalJsonOptions.Default`. Pass an explicit `HalJsonOptions` instance to isolate behavior from the global default.
+
+### ASP.NET Core integration
+
+```csharp
+builder.Services.AddControllers().AddJsonOptions(o =>
+    o.JsonSerializerOptions.AddHalConverters());
+```
+
+This wires all HAL converters into the ASP.NET Core serializer pipeline. To use a custom `HalJsonOptions` for all HAL responses globally:
+
+```csharp
+builder.Services.AddControllers().AddJsonOptions(o =>
+    o.JsonSerializerOptions.AddHalConverters(
+        new HalJsonOptions { AlwaysUseArrayForLinks = true }));
+```
+
+---
+
+## 4. Force-Array Serialization
+
+There are two independent mechanisms for forcing a link relation to serialize as a JSON array rather than a single object.
+
+### 4.1 Per-relation — builder API
+
+Call `.AsArray()` on the link creation stage immediately after `AddLink()` / `AddSelf()` / `AddCuries()`:
+
+```csharp
+var resource = ResourceBuilder.WithState(new { })
+    .AddLink("ea:orders").AsArray()
+        .AddLinkObject("/orders/1")
+    .Build();
+```
+
+`.AsArray()` can also be called on the link object properties stage (after `AddLinkObject()`), which traverses up to the parent `LinkBuilder` via `FindParent<Link>()`:
+
+```csharp
+var resource = ResourceBuilder.WithState(new { })
+    .AddLink("ea:orders")
+        .AddLinkObject("/orders/1").AsArray()
+    .Build();
+```
+
+Both paths converge at `LinkBuilder.SetIsArray()`, which sets `_isArray = true`. When `BuildPart()` is called, `Link.IsArray` is set to `true` on the resulting domain object.
+
+### 4.2 Global — options
+
+**Option A:** Mutate `Default` at application startup:
+
+```csharp
+HalJsonOptions.Default.AlwaysUseArrayForLinks = true;
+```
+
+**Option B:** Supply a per-options instance:
+
+```csharp
+var options = new JsonSerializerOptions().AddHalConverters(
+    new HalJsonOptions { AlwaysUseArrayForLinks = true });
+```
+
+### 4.3 Which converters respect which flag
+
+| Converter | `Link.IsArray` | `AlwaysUseArrayForLinks` |
+|---|---|---|
+| `LinkCollectionConverter` | Yes | Yes |
+| `LinkConverter` | Yes | Yes |
+| `LinkObjectCollectionConverter` | No | Yes |
+
+`LinkCollectionConverter` and `LinkConverter` apply `forceArray = AlwaysUseArrayForLinks || link.IsArray`. `LinkObjectCollectionConverter` only checks `AlwaysUseArrayForLinks` (it does not have access to a parent `Link`).
+
+### 4.4 Output examples
+
+Single-link relation **without** force-array:
+
+```json
+{
+  "_links": {
+    "self": { "href": "/orders/1" }
+  }
+}
+```
+
+Single-link relation **with** force-array (either mechanism):
+
+```json
+{
+  "_links": {
+    "self": [{ "href": "/orders/1" }]
+  }
+}
+```
+
+### 4.5 `EmbeddedResource.ForceWriteAsCollection`
+
+This is a separate flag that applies to embedded resource collections, not link relations. It ensures an embedded entry serializes as a JSON array even when only one resource is present.
+
+`ForceWriteAsCollection` is set automatically by the builder when `AddResources<T>(...)` is called — the bulk-add path that takes an `IEnumerable<T>`:
+
+```csharp
+ResourceCollectionBuilder.AddResources<T>(resources, builder?)
+// sets ForceWriteAsCollection = true unconditionally
+```
+
+`EmbeddedResourceBuilder.BuildPart()` propagates the flag to the constructed `EmbeddedResource`:
+
+```csharp
+return new EmbeddedResource(_name)
+{
+    Resources = _resourceCollectionBuilder.BuildPart(),
+    ForceWriteAsCollection = _resourceCollectionBuilder.ForceWriteAsCollection
+};
+```
+
+`EmbeddedResourceCollectionConverter.Write` then checks this flag:
+
+```csharp
+if (embeddedvalue.Resources.Count == 1 && !embeddedvalue.ForceWriteAsCollection)
+    // write as object
+else
+    // write as array
+```
+
+There is no public builder API to set `ForceWriteAsCollection` independently. It is exclusively a consequence of using `AddResources<T>(...)`.
+
+---
+
+## 5. Deserialization Behavior
+
+### 5.1 `ResourceConverter.Read`
+
+Parses the entire JSON input into a `JsonNode` tree. Rather than immediately deserializing `_links` and `_embedded`, it captures three lazy `Func<T>` delegates:
+
+- `linkCollectionCreator` — deserializes `node["_links"]` on first access of `Resource.Links`
+- `embeddedCollectionCreator` — deserializes `node["_embedded"]` on first access of `Resource.Embedded`
+- `jsonObjectCreator` — clones the node, removes `_links` and `_embedded`, returns the remainder as the state `JsonObject`
+
+These delegates are allocated once and evaluated only when the corresponding property is first accessed. This means deserialization of linked and embedded sub-graphs is deferred until needed.
+
+### 5.2 `LinkCollectionConverter.Read`
+
+Handles three input shapes for each link relation value:
+
+| Shape | Behavior |
+|---|---|
+| JSON object (`{ "href": "..." }`) | Deserializes as a single `LinkObject`; `Link.IsArray` remains `false` |
+| JSON array (`[{ "href": "..." }, ...]`) | Deserializes as `LinkObjectCollection`; sets `Link.IsArray = true` |
+| JSON string (`"rel": "/path"`) | Creates a `LinkObject` with that string as `href` |
+| `null` | Creates a `Link` with no `LinkObjects` |
+
+### 5.3 `LinkConverter.Read`
+
+Expects a single-property JSON object where the property name is the link relation. Returns `null` (tolerant, does not throw) for any of these malformed inputs:
+
+- Not a JSON object
+- A JSON object with more than one property
+- A blank relation key
+- A link object value missing `href`
+- An array entry missing `href`
+
+When the value is a JSON array, sets `Link.IsArray = true` on the resulting `Link`.
+
+### 5.4 `Resource.State<T>()`
+
+Lazily deserializes the resource's state portion into a strongly typed object:
+
+```csharp
+public T? State<T>() where T : class
+```
+
+- If the internal state is a `JsonElement`, deserializes it to `T` and caches the result.
+- If the internal state is null, invokes the `_stateCreator` delegate (which returns the JSON minus `_links`/`_embedded`) and deserializes that.
+- Returns `null` on any exception.
+- **Special guard:** When `T == typeof(Link)`, requires the JSON object to have exactly one property before deserializing. This prevents a multi-property state DTO from being misidentified as a HAL link.
+
+### 5.5 `Resource.As<T>()`
+
+Casts the entire `Resource` (including `_links` and `_embedded`) to a strongly typed object:
+
+```csharp
+public T? As<T>() where T : class
+```
+
+- Serializes the `Resource` to a `JsonNode` via `JsonSerializer.SerializeToNode(this)` if not already cached in `_resourceNode`.
+- Deserializes that node to `T`.
+- Returns `null` on any exception.
+- The `_resourceNode` is cached after the first call — subsequent calls to `As<T>()` skip re-serialization.
+- Because the full resource (including `_links` and `_embedded`) is included in the serialized node, use this method for DTOs decorated with `[HalResponse]` (from the source generator) that declare `Links` and `Embedded` properties.
+
+### 5.6 `EmbeddedResourceCollectionConverter.Read`
+
+Dispatches per embedded entry based on whether the JSON value is an object or an array:
+
+| Value shape | Behavior |
+|---|---|
+| JSON object | Deserializes as a single `Resource`; adds to `EmbeddedResource.Resources` |
+| JSON array | Deserializes as `ResourceCollection`; assigns entire collection to `EmbeddedResource.Resources` |
+| `null` or other | Leaves `EmbeddedResource.Resources` empty |
+
+---
+
+## 6. Media Type
+
+```csharp
+public const string MediaType = "application/hal+json";
+```
+
+`Resource.MediaType` is the normative HAL media type as defined in Section 4 of the HAL specification. Use this constant when setting `Content-Type` or `Accept` headers rather than hard-coding the string:
+
+```csharp
+response.ContentType = Resource.MediaType;
+// or
+request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(Resource.MediaType));
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -90,3 +90,184 @@ Notes & tips
 - The examples are intentionally small so they can be pasted into unit tests or simple console apps for verification.
 
 If you need a compact API reference, see docs/api.md.
+
+---
+
+5) Force-array serialization
+
+The HAL spec recommends that servers keep the shape of a link relation stable across responses. If a relation sometimes returns one link and sometimes multiple, always serializing as an array prevents clients from breaking when the count changes.
+
+**Why it matters**
+
+Without force-array, a single link object serializes as a plain JSON object:
+
+```json
+"self": { "href": "/orders" }
+```
+
+With force-array enabled (per-relation or globally), it always serializes as a JSON array:
+
+```json
+"self": [{ "href": "/orders" }]
+```
+
+Clients that only handle arrays will break on the first form. Stabilizing the shape at build time or at startup removes that fragility.
+
+**Per-relation — call `AsArray()` on the link creation stage**
+
+`AsArray()` can be called after `AddLink()` (before any `AddLinkObject()`) or after `AddLinkObject()`. Both positions produce the same result.
+
+```csharp
+// AsArray() before AddLinkObject — declares intent up front
+var resource = ResourceBuilder.WithState(new { })
+    .AddSelf().AddLinkObject("/orders")
+    .AddLink("ea:orders").AsArray()
+        .AddLinkObject("/orders/1")
+    .Build();
+
+// AsArray() after AddLinkObject — equivalent result
+var resource = ResourceBuilder.WithState(new { })
+    .AddSelf().AddLinkObject("/orders")
+    .AddLink("ea:orders")
+        .AddLinkObject("/orders/1").AsArray()
+    .Build();
+```
+
+**Global — configure `HalJsonOptions` at startup**
+
+Mutate `HalJsonOptions.Default` once at application startup, before any serialization occurs. This affects all attribute-wired converters for the lifetime of the process.
+
+```csharp
+// Affects all serialization that uses attribute-wired converters
+HalJsonOptions.Default.AlwaysUseArrayForLinks = true;
+```
+
+Or scope it to a specific `JsonSerializerOptions` instance (see section 6 for `AddHalConverters`):
+
+```csharp
+var options = new JsonSerializerOptions()
+    .AddHalConverters(new HalJsonOptions { AlwaysUseArrayForLinks = true });
+
+var json = JsonSerializer.Serialize(resource, options);
+```
+
+---
+
+6) `HalJsonOptions` and `AddHalConverters`
+
+By default the library wires converters via `[JsonConverter]` attributes on domain types. No setup is required for basic serialization. When you need custom options — indentation, force-array, ASP.NET Core integration — use `AddHalConverters()`.
+
+```csharp
+// Default wiring — no setup needed
+var json = JsonSerializer.Serialize(resource);
+
+// Explicit options with default HalJsonOptions
+var options = new JsonSerializerOptions { WriteIndented = true }
+    .AddHalConverters();
+var json = JsonSerializer.Serialize(resource, options);
+
+// Explicit options with custom HalJsonOptions
+var options = new JsonSerializerOptions()
+    .AddHalConverters(new HalJsonOptions { AlwaysUseArrayForLinks = true });
+var json = JsonSerializer.Serialize(resource, options);
+
+// ASP.NET Core integration
+builder.Services.AddControllers()
+    .AddJsonOptions(o => o.JsonSerializerOptions.AddHalConverters());
+```
+
+`AddHalConverters()` is idempotent — calling it more than once on the same `JsonSerializerOptions` instance is safe and has no effect after the first call.
+
+Note: when you supply explicit `JsonSerializerOptions` to `JsonSerializer`, the options-registered converters from `AddHalConverters()` take precedence over the attribute-wired converters. Both code paths produce identical HAL output under the same `HalJsonOptions`.
+
+---
+
+7) Deserialization and navigation extensions
+
+After deserializing a HAL document to a `Resource`, use the extension methods in `ResourceExtensions`, `LinkCollectionExtensions`, and `ResourceCollectionExtensions` to navigate it without manual null checks or LINQ.
+
+```csharp
+using System.Text.Json;
+using Chatter.Rest.Hal;
+
+var resource = JsonSerializer.Deserialize<Resource>(json);
+
+// Access state as a strongly-typed DTO
+var state = resource.State<MyStateDto>();
+
+// Cast the Resource directly to a typed DTO (useful with [HalResponse] DTOs — see section 8)
+var dto = resource.As<MyResponseDto>();
+
+// Get the Link (rel + its link objects) for a relation
+var selfLink = resource.GetLinkOrDefault("self");
+
+// Get the first link object for a relation
+var selfLinkObject = resource.GetLinkObjectOrDefault("self");
+var selfHref = selfLinkObject?.Href;
+
+// Get a named link object within a relation (e.g., one of several ea:admin entries)
+var adminLink = resource.GetLinkObjectOrDefault("ea:admin", "Fred");
+
+// Get the full collection of link objects for a relation
+var orderLinks = resource.GetLinkObjects("ea:order");
+
+// Navigate embedded resources — returns IEnumerable<OrderDto?>
+var orders = resource.GetEmbeddedResources<OrderDto>("ea:order");
+
+// CURIE expansion — resolves a compact relation to its full URI
+// Given a curies entry: { "name": "ea", "href": "http://example.com/docs/rels/{rel}", "templated": true }
+var expandedRel = resource.Links.ExpandCurieRelation("ea:find");
+// returns "http://example.com/docs/rels/find"
+// Returns the original relation unchanged if no matching CURIE definition is found.
+```
+
+---
+
+8) `[HalResponse]` source generator
+
+The `Chatter.Rest.Hal.CodeGenerators` package generates HAL properties on your DTOs at compile time so that your response class serializes directly as a HAL document without needing `Resource` as a wrapper.
+
+**Package setup**
+
+```bash
+dotnet add package Chatter.Rest.Hal.CodeGenerators
+dotnet add package Chatter.Rest.Hal.Core
+```
+
+**Decorate your DTO**
+
+Your class must be `partial`, non-generic, and non-nested.
+
+```csharp
+using Chatter.Rest.Hal;
+
+[HalResponse]
+public partial class OrderResponse
+{
+    public string Id { get; set; }
+    public decimal Total { get; set; }
+}
+```
+
+**What the generator produces (at compile time, in `obj/`)**
+
+```csharp
+public partial class OrderResponse
+{
+    [JsonPropertyName("_links")]
+    public LinkCollection? Links { get; set; }
+
+    [JsonPropertyName("_embedded")]
+    public EmbeddedResourceCollection? Embedded { get; set; }
+}
+```
+
+`OrderResponse` now has `_links` and `_embedded` properties with the correct JSON names. When serialized with `System.Text.Json`, it produces a valid HAL document.
+
+**Constraints**
+
+| Constraint | Reason |
+|---|---|
+| Class must be `partial` | The generator needs to emit into the same type declaration |
+| Class must be non-generic | Type parameter substitution is not supported by the generator |
+| Class must be non-nested | Roslyn emit targets top-level type declarations only |


### PR DESCRIPTION
## Summary

- **`docs/architecture.md`** (new, 427 lines) — domain model ownership diagram, staged builder pattern with class/stage hierarchy, converter architecture with read/write behavior per converter, Roslyn source generator pipeline, package relationships
- **`docs/serialization.md`** (new, 313 lines) — deep dive into HalJsonOptions, AddHalConverters(), force-array mechanisms (per-relation vs. global), converter-level read/write internals, deserialization behavior, ASP.NET Core integration
- **`docs/api.md`** (overhauled, 55→520 lines) — full public API surface replacing the old stub; fixes incorrect return types (`EmbeddedBuilder`/`ResourceBuilder` → stage interfaces), correct `AddResources<T>` callback signature, adds `AsArray()` in all contexts, all 6 extension classes, serialization config API, source generator reference
- **`docs/usage.md`** (expanded, 92→273 lines) — adds force-array patterns, `HalJsonOptions`/`AddHalConverters` usage, navigation extension examples, `[HalResponse]` code gen usage with before/after
- **`docs/development.md`** (rewritten, 75→141 lines) — replaces generic boilerplate with exact project paths, dotnet commands, CI/CD parity notes, source gen output location, test conventions

## Test plan

- [ ] Review `docs/architecture.md` for accuracy against source
- [ ] Review `docs/api.md` — verify stage interface signatures and extension method signatures match source
- [ ] Review `docs/serialization.md` — verify force-array table and converter behavior descriptions
- [ ] Review `docs/usage.md` — verify code examples compile and produce described output
- [ ] Review `docs/development.md` — verify all commands and paths are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)