### PR TITLE
perf: implement PERF-06 through PERF-13 performance improvements

### DIFF
--- a/docs/performance-todo.md
+++ b/docs/performance-todo.md
@@ -194,7 +194,8 @@ Note: `writer.WriteRawValue` requires `System.Text.Json` 6+. The filter for `"Li
 - **Impact:** Medium
 - **Effort:** Low
 - **Category:** allocation / collection
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** Added public read-only `this[int index]` indexer to LinkObjectCollection, LinkCollection, ResourceCollection, EmbeddedResourceCollection (delegating to backing Collection<T>). Replaced .First() with [0] in all 5 converter call sites. Removed unused using System.Linq from 4 of 5 converters. Committed in perf/remaining-fixes.
 
 ### Problem
 `.First()` on `Collection<T>`-backed types calls `IEnumerable<T>.GetEnumerator()` which boxes the struct enumerator. Happens on every single-element link/resource write -- the most common HAL serialization case per the spec.
@@ -222,7 +223,8 @@ All backing collection types already wrap `Collection<T>` which supports `[int i
 - **Impact:** Medium
 - **Effort:** Low
 - **Category:** allocation
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** Resource.Links and Resource.Embedded getters changed from `return _impl ?? new T()` to `_impl = _creator() ?? new T(); return _impl` — fallback collection allocated once and cached. Committed in perf/remaining-fixes.
 
 ### Problem
 `return _linksImpl ?? new LinkCollection()` allocates a new empty collection on every getter access when `_linksCreator()` returned null. `_linksImpl` stays null so subsequent accesses each allocate.
@@ -262,7 +264,8 @@ Apply same fix to `Embedded` getter (`_embeddedImpl` / `EmbeddedResourceCollecti
 - **Impact:** Medium
 - **Effort:** Low
 - **Category:** json
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** TryGetBooleanAsTrue and TryGetString in LinkObjectConverter replaced try/catch + GetValue<T>() with `node is JsonValue jv && jv.TryGetValue<T>(out var value)` pattern. No #if guard needed — TryGetValue<T> available on netstandard2.0 via System.Text.Json 6.x. Committed in perf/remaining-fixes.
 
 ### Problem
 `TryGetBooleanAsTrue` and `TryGetString` use try/catch for control flow when `GetValue<T>()` throws on type mismatch. Exception handling is expensive -- allocates stack trace, unwinds frames. Called per property per `LinkObject` on deserialization hot path.
@@ -301,7 +304,8 @@ private static string? TryGetString(JsonNode? node)
 - **Impact:** Medium
 - **Effort:** Low
 - **Category:** generator
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** HalResponseGenerator.cs switched from CreateSyntaxProvider to ForAttributeWithMetadataName("Chatter.Rest.Hal.HalResponseAttribute"). Microsoft.CodeAnalysis.CSharp.Workspaces bumped 4.1.0 → 4.3.1. Parser.cs deleted (all methods became dead code). Committed in perf/remaining-fixes.
 
 ### Problem
 `CreateSyntaxProvider` with manual syntax filter + semantic model query runs semantic analysis on every `AttributeSyntax` in the compilation on every keystroke in the IDE. `ForAttributeWithMetadataName` (available since Microsoft.CodeAnalysis.CSharp 4.3.1) uses Roslyn's internal attribute cache and is significantly more efficient -- it avoids re-running semantic analysis on unchanged files.
@@ -335,7 +339,8 @@ Requires bumping `Microsoft.CodeAnalysis.CSharp` / `Microsoft.CodeAnalysis.CShar
 - **Impact:** Medium
 - **Effort:** Low
 - **Category:** generator
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** Introduced HalClassInfo readonly struct as typed intermediate result. Dedup/sort LINQ chain moved from Emitter.Emit into a .Select() cached transform in HalResponseGenerator. Emitter.Emit now receives pre-processed ImmutableArray<HalClassInfo>. EnumerableExtensions.cs deleted (NotNull<T> became dead code). Committed in perf/remaining-fixes.
 
 ### Problem
 The LINQ chain `.NotNull().Select().GroupBy().Select().OrderBy().ThenBy().ToArray()` runs inside `RegisterSourceOutput`, which Roslyn cannot cache. This runs on every generation pass even when inputs have not changed.
@@ -377,7 +382,8 @@ Use `ImmutableArray<T>` as the return type from the `.Select(...)` transform -- 
 - **Impact:** Medium
 - **Effort:** Low
 - **Category:** allocation
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** Added internal object? CachedState property to Resource — lazily resolves state via _stateCreator()?.Deserialize<object>() without try/catch. ResourceConverter.Write now uses value.CachedState instead of value.StateObject. Public State<T>() retains try/catch for consumer safety. Committed in perf/remaining-fixes.
 
 ### Problem
 `StateObject` (internal getter used by `ResourceConverter.Write`) calls `State<object>()` which wraps deserialization in a try/catch block. This try/catch executes on every resource serialization even after state is cached, because the getter calls the method rather than accessing `_stateObject` directly.
@@ -405,7 +411,8 @@ Then update `ResourceConverter.Write` to use `value.CachedState` instead of `val
 - **Impact:** Low
 - **Effort:** Low
 - **Category:** allocation
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** AddHalConverters duplicate guard replaced with a for-loop checking options.Converters[i] is LinkCollectionConverter. Removed now-unused using System.Linq from JsonSerializerOptionsExtensions.cs. Committed in perf/remaining-fixes.
 
 ### Problem
 `options.Converters.OfType<LinkCollectionConverter>().Any()` allocates a LINQ enumerator to check for duplicate converters. Called at startup/configuration time -- not a hot path, but easy to improve.
@@ -433,7 +440,8 @@ if (!alreadyAdded) { /* add converters */ }
 - **Impact:** Low
 - **Effort:** Medium
 - **Category:** collection
-- **Status:** - [ ] pending
+- **Status:** - [x] complete
+- **Implementation Note:** Added private Dictionary<string, Link> _index (StringComparer.Ordinal) to LinkCollection and Dictionary<string, EmbeddedResource> _index to EmbeddedResourceCollection. Index maintained on Add/Remove/Clear. Exposed TryGetByRel(string, out Link?) and TryGetByName(string, out EmbeddedResource?) for O(1) lookup. Extension methods (GetLinkOrDefault, GetEmbeddedResource) retain SingleOrDefault semantics — throws on duplicate rels per existing tests. Committed in perf/remaining-fixes.
 
 ### Problem
 `links.SingleOrDefault(l => l.Rel.Equals(relation))` and equivalent do a linear O(n) scan with LINQ allocation. For HATEOAS-heavy responses with 20+ link relations, this is O(n) per lookup. The `LinkCollection` and `EmbeddedResourceCollection` types wrap `Collection<T>` and have no index.

--- a/src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj
+++ b/src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.3.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Chatter.Rest.Hal.CodeGenerators/Emitter.cs
+++ b/src/Chatter.Rest.Hal.CodeGenerators/Emitter.cs
@@ -1,36 +1,53 @@
-﻿using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Chatter.Rest.Hal.CodeGenerators;
 
+internal readonly struct HalClassInfo : IEquatable<HalClassInfo>
+{
+	internal string Name { get; }
+	internal string? Namespace { get; }
+
+	internal HalClassInfo(string name, string? ns)
+	{
+		Name = name;
+		Namespace = ns;
+	}
+
+	public bool Equals(HalClassInfo other) =>
+		Name == other.Name && Namespace == other.Namespace;
+
+	public override bool Equals(object? obj) =>
+		obj is HalClassInfo other && Equals(other);
+
+	public override int GetHashCode()
+	{
+		unchecked
+		{
+			return (Name.GetHashCode() * 397) ^ (Namespace?.GetHashCode() ?? 0);
+		}
+	}
+}
+
 internal class Emitter
 {
 	internal static void Emit(SourceProductionContext context,
-		ImmutableArray<ClassDeclarationSyntax?> halResponseClasses)
+		ImmutableArray<HalClassInfo> halResponseClasses)
 	{
 		if (halResponseClasses.IsDefaultOrEmpty)
 		{
 			return;
 		}
 
-		var classes = halResponseClasses.NotNull()
-			.Select(c => new { Type = c, Name = c.Identifier.Text, Namespace = GetNamespaceFrom(c) ?? string.Empty })
-			.GroupBy(x => (x.Namespace, x.Name))
-			.Select(g => g.First())
-			.OrderBy(x => x.Namespace, StringComparer.Ordinal)
-			.ThenBy(x => x.Name, StringComparer.Ordinal)
-			.ToArray();
-		foreach (var entry in classes)
+		foreach (var entry in halResponseClasses)
 		{
-			AddSource(context, entry.Type, entry.Name, string.IsNullOrEmpty(entry.Namespace) ? null : entry.Namespace);
+			AddSource(context, entry.Name, string.IsNullOrEmpty(entry.Namespace) ? null : entry.Namespace);
 		}
 	}
 
-	private static void AddSource(SourceProductionContext context, ClassDeclarationSyntax type, string name, string? ns)
+	private static void AddSource(SourceProductionContext context, string name, string? ns)
 	{
 		var code = GenerateCode(name, ns);
 		var typeNamespace = ns is null ? string.Empty : $"{ns}.";
@@ -67,10 +84,10 @@ internal class Emitter
         {
             sb.AppendLine("}");
         }
-        return sb.ToString();
+        return sb.ToString();
     }
 
-	private static string? GetNamespaceFrom(SyntaxNode s) =>
+	internal static string? GetNamespaceFrom(SyntaxNode s) =>
 		s.Parent switch
 		{
 			FileScopedNamespaceDeclarationSyntax fileScopedNamespace => fileScopedNamespace.Name.ToString(),

--- a/src/Chatter.Rest.Hal.CodeGenerators/HalResponseGenerator.cs
+++ b/src/Chatter.Rest.Hal.CodeGenerators/HalResponseGenerator.cs
@@ -1,4 +1,7 @@
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Chatter.Rest.Hal.CodeGenerators;
 
@@ -8,13 +11,27 @@ public class HalResponseGenerator : IIncrementalGenerator
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
         var halResponseTypes = context.SyntaxProvider
-            .CreateSyntaxProvider(
-                static (node, _) => Parser.IsSyntaxTargetForGeneration(node),
-                static (ctx, _) => Parser.GetSemanticTargetForGeneration(ctx)
-            )
-            .Where(static type => type is not null)
-            .Collect();
+            .ForAttributeWithMetadataName(
+                "Chatter.Rest.Hal.HalResponseAttribute",
+                static (node, _) => node is ClassDeclarationSyntax,
+                static (ctx, _) => (ClassDeclarationSyntax)ctx.TargetNode
+            );
 
-        context.RegisterSourceOutput(halResponseTypes, Emitter.Emit);
+        var processedTypes = halResponseTypes
+            .Collect()
+            .Select(static (types, _) =>
+                types
+                    .Where(static t => t is not null)
+                    .Select(static c => new HalClassInfo(
+                        c!.Identifier.Text,
+                        Emitter.GetNamespaceFrom(c)))
+                    .GroupBy(static x => (x.Namespace ?? string.Empty, x.Name))
+                    .Select(static g => g.First())
+                    .OrderBy(static x => x.Namespace ?? string.Empty, StringComparer.Ordinal)
+                    .ThenBy(static x => x.Name, StringComparer.Ordinal)
+                    .ToImmutableArray());
+
+        context.RegisterSourceOutput(processedTypes, static (ctx, classes) =>
+            Emitter.Emit(ctx, classes));
     }
 }

--- a/src/Chatter.Rest.Hal.CodeGenerators/packages.lock.json
+++ b/src/Chatter.Rest.Hal.CodeGenerators/packages.lock.json
@@ -4,14 +4,14 @@
     ".NETStandard,Version=v2.0": {
       "Microsoft.CodeAnalysis.CSharp.Workspaces": {
         "type": "Direct",
-        "requested": "[4.1.0, )",
-        "resolved": "4.1.0",
-        "contentHash": "VXAz9xHBcgAXr5+WD9tT4S/bfW0x7raIUB5DPsnXpOrlOcN1RuDBq2UYofK8L693u63FNuRWI3BcFjFdprMhIg==",
+        "requested": "[4.3.1, )",
+        "resolved": "4.3.1",
+        "contentHash": "mRTePOunrPzWkUT7I/FUQF6EFopAuYt0EiYbznkULOyHFT9eHDtN+gaHxqx9or/edAXgpm0KVeybQ83ri/M9Ww==",
         "dependencies": {
-          "Humanizer.Core": "2.2.0",
-          "Microsoft.CodeAnalysis.CSharp": "[4.1.0]",
-          "Microsoft.CodeAnalysis.Common": "[4.1.0]",
-          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.1.0]"
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.CSharp": "[4.3.1]",
+          "Microsoft.CodeAnalysis.Common": "[4.3.1]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[4.3.1]"
         }
       },
       "NETStandard.Library": {
@@ -25,16 +25,13 @@
       },
       "Humanizer.Core": {
         "type": "Transitive",
-        "resolved": "2.2.0",
-        "contentHash": "rsYXB7+iUPP8AHgQ8JP2UZI2xK2KhjcdGr9E6zX3CsZaTLCaw8M35vaAJRo1rfxeaZEVMuXeaquLVCkZ7JcZ5Q==",
-        "dependencies": {
-          "NETStandard.Library": "1.6.1"
-        }
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "W8DPQjkMScOMTtJbPwmPyj9c3zYSFGawDW3jwlBOOsnY+EzZFLgNQ/UMkK35JmkNOVPdCyPr2Tw7Vv9N+KA3ZQ==",
+        "resolved": "6.0.0",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
         "dependencies": {
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
@@ -46,36 +43,36 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "4.1.0",
-        "contentHash": "bNzTyxP3iD5FPFHfVDl15Y6/wSoI7e3MeV0lOaj9igbIKTjgrmuw6LoVJ06jUNFA7+KaDC/OIsStWl/FQJz6sQ==",
+        "resolved": "4.3.1",
+        "contentHash": "wexpJffSEEwptwe6UTMxRDZCCtz+XubI4Qewl4JECnNhcQrtb0anhSUEV9Nz7WkoNfWkx1fptR8xh1egoxYrqw==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Analyzers": "3.3.3",
-          "System.Collections.Immutable": "5.0.0",
+          "System.Collections.Immutable": "6.0.0",
           "System.Memory": "4.5.4",
           "System.Reflection.Metadata": "5.0.0",
-          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
-          "System.Text.Encoding.CodePages": "4.5.1",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encoding.CodePages": "6.0.0",
           "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Transitive",
-        "resolved": "4.1.0",
-        "contentHash": "sbu6kDGzo9bfQxuqWpeEE7I9P30bSuZEnpDz9/qz20OU6pm79Z63+/BsAzO2e/R/Q97kBrpj647wokZnEVr97w==",
+        "resolved": "4.3.1",
+        "contentHash": "5C9VHvahL98tumlyaT/loB5rW+K/6q0UU7uLyT1Dv15YjZraRkqML9u2t2e8GaO7XqEOtBVqK/SlxXOPqwzxog==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[4.1.0]"
+          "Microsoft.CodeAnalysis.Common": "[4.3.1]"
         }
       },
       "Microsoft.CodeAnalysis.Workspaces.Common": {
         "type": "Transitive",
-        "resolved": "4.1.0",
-        "contentHash": "Xzb15T20r9qDN0REgTZLdKTzXsZr/zxAy8Jq/w00y32wrJGBZLPz8mR2KLZ1f1ujv5jaQZ040GPmmFVYz8c2ag==",
+        "resolved": "4.3.1",
+        "contentHash": "PtkBobNNtAJ6teR/tzuDGf4829DcIUJJqN4wRtshRG28Xs+DRvnE4znFvZWJ8hsnBWGsywqjpRYjvoAdIYi3NA==",
         "dependencies": {
-          "Humanizer.Core": "2.2.0",
-          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
-          "Microsoft.CodeAnalysis.Common": "[4.1.0]",
-          "System.Composition": "1.0.31",
-          "System.IO.Pipelines": "5.0.1"
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "Microsoft.CodeAnalysis.Common": "[4.3.1]",
+          "System.Composition": "6.0.0",
+          "System.IO.Pipelines": "6.0.3"
         }
       },
       "Microsoft.NETCore.Platforms": {
@@ -83,216 +80,76 @@
         "resolved": "1.1.0",
         "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       },
-      "Microsoft.NETCore.Targets": {
-        "type": "Transitive",
-        "resolved": "1.1.0",
-        "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
-      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
         "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
       },
-      "System.Collections": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3Dcj85/TBdVpL5Zr+gEEBUuFe2icOnLalmEh9hfck1PTYbbyWuZgh4fmm2ysCLTrqLQw6t3TgTyJ+VLp+Qb+Lw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
       "System.Collections.Immutable": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "FXkLXiK0sVVewcso0imKQoOxjoPAj42R8HtjjbSjVPAzwDfzoyoznWxgA3c38LDbN9SJux1xXoXYAhz98j7r2g==",
+        "resolved": "6.0.0",
+        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
         "dependencies": {
-          "System.Memory": "4.5.4"
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Composition": {
         "type": "Transitive",
-        "resolved": "1.0.31",
-        "contentHash": "I+D26qpYdoklyAVUdqwUBrEIckMNjAYnuPJy/h9dsQItpQwVREkDFs4b4tkBza0kT2Yk48Lcfsv2QQ9hWsh9Iw==",
+        "resolved": "6.0.0",
+        "contentHash": "d7wMuKQtfsxUa7S13tITC8n1cQzewuhD5iDjZtK2prwFfKVzdYtgrTHgjaV03Zq7feGQ5gkP85tJJntXwInsJA==",
         "dependencies": {
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Convention": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Composition.TypedParts": "1.0.31"
+          "System.Composition.AttributedModel": "6.0.0",
+          "System.Composition.Convention": "6.0.0",
+          "System.Composition.Hosting": "6.0.0",
+          "System.Composition.Runtime": "6.0.0",
+          "System.Composition.TypedParts": "6.0.0"
         }
       },
       "System.Composition.AttributedModel": {
         "type": "Transitive",
-        "resolved": "1.0.31",
-        "contentHash": "NHWhkM3ZkspmA0XJEsKdtTt1ViDYuojgSND3yHhTzwxepiwqZf+BCWuvCbjUt4fe0NxxQhUDGJ5km6sLjo9qnQ==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "WK1nSDLByK/4VoC7fkNiFuTVEiperuCN/Hyn+VN30R+W2ijO1d0Z2Qm0ScEl9xkSn1G2MyapJi8xpf4R8WRa/w=="
       },
       "System.Composition.Convention": {
         "type": "Transitive",
-        "resolved": "1.0.31",
-        "contentHash": "GLjh2Ju71k6C0qxMMtl4efHa68NmWeIUYh4fkUI8xbjQrEBvFmRwMDFcylT8/PR9SQbeeL48IkFxU/+gd0nYEQ==",
+        "resolved": "6.0.0",
+        "contentHash": "XYi4lPRdu5bM4JVJ3/UIHAiG6V6lWWUlkhB9ab4IOq0FrRsp0F4wTyV4Dj+Ds+efoXJ3qbLqlvaUozDO7OLeXA==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Composition.AttributedModel": "6.0.0"
         }
       },
       "System.Composition.Hosting": {
         "type": "Transitive",
-        "resolved": "1.0.31",
-        "contentHash": "fN1bT4RX4vUqjbgoyuJFVUizAl2mYF5VAb+bVIxIYZSSc0BdnX+yGAxcavxJuDDCQ1K+/mdpgyEFc8e9ikjvrg==",
+        "resolved": "6.0.0",
+        "contentHash": "w/wXjj7kvxuHPLdzZ0PAUt++qJl03t7lENmb2Oev0n3zbxyNULbWBlnd5J5WUMMv15kg5o+/TCZFb6lSwfaUUQ==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
+          "System.Composition.Runtime": "6.0.0"
         }
       },
       "System.Composition.Runtime": {
         "type": "Transitive",
-        "resolved": "1.0.31",
-        "contentHash": "0LEJN+2NVM89CE4SekDrrk5tHV5LeATltkp+9WNYrR+Huiyt0vaCqHbbHtVAjPyeLWIc8dOz/3kthRBj32wGQg==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "qkRH/YBaMPTnzxrS5RDk1juvqed4A6HOD/CwRcDGyPpYps1J27waBddiiq1y93jk2ZZ9wuA/kynM+NO0kb3PKg=="
       },
       "System.Composition.TypedParts": {
         "type": "Transitive",
-        "resolved": "1.0.31",
-        "contentHash": "0Zae/FtzeFgDBBuILeIbC/T9HMYbW4olAmi8XqqAGosSOWvXfiQLfARZEhiGd0LVXaYgXr0NhxiU1LldRP1fpQ==",
+        "resolved": "6.0.0",
+        "contentHash": "iUR1eHrL8Cwd82neQCJ00MpwNIBs4NZgXzrPqx8NJf/k4+mwBO0XCRmHYJT4OLSwDDqh5nBLJWkz5cROnrGhRA==",
         "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Composition.AttributedModel": "1.0.31",
-          "System.Composition.Hosting": "1.0.31",
-          "System.Composition.Runtime": "1.0.31",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Diagnostics.Tools": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.Linq.Expressions": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0"
-        }
-      },
-      "System.Diagnostics.Debug": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "ZUhUOdqmaG5Jk3Xdb8xi5kIyQYAA4PnTNlHx1mu9ZY3qv4ELIdKbnL/akbGaKi2RnNUWaZsAs31rvzFdewTj2g==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Diagnostics.Tools": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "UUvkJfSYJMM6x527dJg2VyWPSRqIVB0Z7dbjHst1zmwTXz5CcXSYJFWRpuigfbO1Lf7yfZiIaEUesfnl/g5EyA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Globalization": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "kYdVd2f2PAdFGblzFswE4hkNANJBKRmsfa2X5LG2AcWE1c7/4t0pYae1L8vfZ5xvE2nK/R9JprtToA61OSHWIg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.IO": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "3qjaHvxQPDpSOYICjUoTsmoq5u6QJAFRUITgeT/4gqkF1bajbSmb1kwSxEA8AHlofqgcKJcM8udgieRNhaJ5Cg==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0",
-          "System.Text.Encoding": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
+          "System.Composition.AttributedModel": "6.0.0",
+          "System.Composition.Hosting": "6.0.0",
+          "System.Composition.Runtime": "6.0.0"
         }
       },
       "System.IO.Pipelines": {
         "type": "Transitive",
-        "resolved": "5.0.1",
-        "contentHash": "qEePWsaq9LoEEIqhbGe6D5J8c9IqQOUuTzzV6wn1POlfdLkJliZY3OlB0j0f17uMWlqZYjH7txj+2YbyrIA8Yg==",
+        "resolved": "6.0.3",
+        "contentHash": "ryTgF+iFkpGZY1vRQhfCzX0xTdlV3pyaTTqRu2ETbEv+HlV7O6y7hyQURnghNIXvctl5DuZ//Dpks6HdL/Txgw==",
         "dependencies": {
           "System.Buffers": "4.5.1",
           "System.Memory": "4.5.4",
           "System.Threading.Tasks.Extensions": "4.5.4"
-        }
-      },
-      "System.Linq": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5DbqIUpsDp0dFftytzuMmc0oeMdQwjcP/EWxsksIz/w1TcFRkZ3yKKz0PqiYFMmEwPSWw+qNVqD7PJ889JzHbw==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0"
-        }
-      },
-      "System.Linq.Expressions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "PGKkrd2khG4CnlyJwxwwaWWiSiWFNBGlgXvJpeO0xCXrZ89ODrQ6tjEWS/kOqZ8GwEOUATtKtzp1eRgmYNfclg==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Globalization": "4.3.0",
-          "System.IO": "4.3.0",
-          "System.Linq": "4.3.0",
-          "System.ObjectModel": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Emit.Lightweight": "4.3.0",
-          "System.Reflection.Extensions": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Reflection.TypeExtensions": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Runtime.Extensions": "4.3.0",
-          "System.Threading": "4.3.0"
         }
       },
       "System.Memory": {
@@ -310,74 +167,6 @@
         "resolved": "4.4.0",
         "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
       },
-      "System.ObjectModel": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "bdX+80eKv9bN6K4N+d77OankKHGn6CH711a6fcOpMQu2Fckp/Ft4L/kW9WznHpyR0NRAvJutzOMHNNlBGvxQzQ==",
-        "dependencies": {
-          "System.Collections": "4.3.0",
-          "System.Diagnostics.Debug": "4.3.0",
-          "System.Resources.ResourceManager": "4.3.0",
-          "System.Runtime": "4.3.0",
-          "System.Threading": "4.3.0"
-        }
-      },
-      "System.Reflection": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "KMiAFoW7MfJGa9nDFNcfu+FpEdiHpWgTcS2HdMpDvt9saK3y/G4GwprPyzqjFH9NTaGPQeWNHU+iDlDILj96aQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.IO": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "228FG0jLcIwTVJyz8CLFKueVqQK36ANazUManGaJHkO0icjiIypKW7YLWLIWahyIkdh5M7mV2dJepllLyA1SKg==",
-        "dependencies": {
-          "System.IO": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit.ILGeneration": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "59tBslAk9733NXLrUJrwNZEzbMAcu8k344OYo+wfSVygcgZ9lgBdGIzH/nrg3LYhXceynyvTc8t5/GD4Ri0/ng==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Emit.Lightweight": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "oadVHGSMsTmZsAF864QYN1t1QzZjIcuKU3l2S9cZOwDdDueNTrqq1yRj7koFfIGEnKpt6NjpL3rOzRhs4ryOgA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Reflection.Emit.ILGeneration": "4.3.0",
-          "System.Reflection.Primitives": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "rJkrJD3kBI5B712aRu4DpSIiHRtr6QlfZSQsb0hYHrDCZORXCFjQfoipo2LaMUHoT9i1B7j7MnfaEKWDFmFQNQ==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
         "resolved": "5.0.0",
@@ -386,96 +175,18 @@
           "System.Collections.Immutable": "5.0.0"
         }
       },
-      "System.Reflection.Primitives": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "5RXItQz5As4xN2/YUDxdpsEkMhvw3e6aNveFXUn4Hl/udNTCNhnKp8lT9fnc3MhvGKh1baak5CovpuQUXHAlIA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Reflection.TypeExtensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "7u6ulLcZbyxB5Gq0nMkQttcdBTx57ibzw+4IOXEfR+sXYQoHvjW5LTLyNr8O22UIMrqYbchJQJnos4eooYzYJA==",
-        "dependencies": {
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Resources.ResourceManager": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "/zrcPkkWdZmI4F92gL/TPumP98AVDu/Wxr3CSJGQQ+XN6wbRZcyfSKVoPo17ilb3iOr0cCRqJInGwNMolqhS8A==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Globalization": "4.3.0",
-          "System.Reflection": "4.3.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Runtime": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "JufQi0vPQ0xGnAczR13AUFglDyVYt4Kqnz1AZaiKZ5+GICq0/1MH/mO/eAJHt/mHW1zjKBJd7kV26SrxddAhiw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0"
-        }
-      },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "ZD9TMpsmYJLrxbbmdvhwt9YEgG5WntEnZ/d1eH8JBX9LBp+Ju8BSBhUGbZMNVHHomWo2KVImJhTDl2hIgw/6MA=="
-      },
-      "System.Runtime.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "guW0uK0fn5fcJJ1tJVXYd7/1h5F+pea1r7FLSOz/f8vPEqbR2ZAknuRDvTQ8PzAilDveOxNjSfr0CHfIQfFk8g==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
-      },
-      "System.Text.Encoding": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "BiIg+KWaSDOITze6jGQynxg64naAPtqGHBwDrLaCtixsa5bKiR8dpPOHA7ge3C0JJQizJE+sfkz1wV+BAKAYZw==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
-        }
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
-        "resolved": "4.5.1",
-        "contentHash": "4J2JQXbftjPMppIHJ7IC+VXQ9XfEagN92vZZNoG12i+zReYlim5dMoXFC1Zzg7tsnKDM7JPo5bYfFK4Jheq44w==",
+        "resolved": "6.0.0",
+        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
         "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "4.5.2"
-        }
-      },
-      "System.Threading": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "VkUS0kOBcUf3Wwm0TSbrevDDZ6BlM+b/HRiapRFWjM5O0NS0LviG0glKmFK+hhPDd1XFeSdU1GmlLhb2CoVpIw==",
-        "dependencies": {
-          "System.Runtime": "4.3.0",
-          "System.Threading.Tasks": "4.3.0"
-        }
-      },
-      "System.Threading.Tasks": {
-        "type": "Transitive",
-        "resolved": "4.3.0",
-        "contentHash": "LbSxKEdOUhVe8BezB/9uOGGppt+nZf6e1VFyw6v3DN6lqitm0OSn2uXMOdtP0M3W4iMcqcivm2J6UgqiwwnXiA==",
-        "dependencies": {
-          "Microsoft.NETCore.Platforms": "1.1.0",
-          "Microsoft.NETCore.Targets": "1.1.0",
-          "System.Runtime": "4.3.0"
+          "System.Memory": "4.5.4",
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
       "System.Threading.Tasks.Extensions": {

--- a/src/Chatter.Rest.Hal/Converters/EmbeddedResourceCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/EmbeddedResourceCollectionConverter.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -90,7 +89,7 @@ public class EmbeddedResourceCollectionConverter : JsonConverter<EmbeddedResourc
             // flagged as a collection, in which case it should be written as an array even if only one element)
             if (embeddedvalue.Resources.Count == 1 && !embeddedvalue.ForceWriteAsCollection)
             {
-                JsonSerializer.Serialize(writer, embeddedvalue.Resources.First(), options);
+                JsonSerializer.Serialize(writer, embeddedvalue.Resources[0], options);
             }
             else
             {

--- a/src/Chatter.Rest.Hal/Converters/LinkCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkCollectionConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -117,7 +116,7 @@ public class LinkCollectionConverter : JsonConverter<LinkCollection>
 			bool forceArray = (_halJsonOptions ?? HalJsonOptions.Default).AlwaysUseArrayForLinks || link.IsArray;
 			if (!forceArray && link.LinkObjects.Count == 1)
 			{
-				JsonSerializer.Serialize(writer, link.LinkObjects.First(), options);
+				JsonSerializer.Serialize(writer, link.LinkObjects[0], options);
 			}
 			else
 			{

--- a/src/Chatter.Rest.Hal/Converters/LinkConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkConverter.cs
@@ -136,7 +136,7 @@ public class LinkConverter : JsonConverter<Link>
 		bool forceArray = (_halJsonOptions ?? HalJsonOptions.Default).AlwaysUseArrayForLinks || value.IsArray;
 		if (!forceArray && value.LinkObjects.Count == 1)
 		{
-			JsonSerializer.Serialize(writer, value.LinkObjects.First(), options);
+			JsonSerializer.Serialize(writer, value.LinkObjects[0], options);
 		}
 		else
 		{

--- a/src/Chatter.Rest.Hal/Converters/LinkObjectCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkObjectCollectionConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -100,7 +99,7 @@ public class LinkObjectCollectionConverter : JsonConverter<LinkObjectCollection>
 		bool forceArray = (_halJsonOptions ?? HalJsonOptions.Default).AlwaysUseArrayForLinks;
 		if (!forceArray && linkObjects.Count == 1)
 		{
-			JsonSerializer.Serialize(writer, linkObjects.First(), options);
+			JsonSerializer.Serialize(writer, linkObjects[0], options);
 		}
 		else
 		{

--- a/src/Chatter.Rest.Hal/Converters/LinkObjectConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/LinkObjectConverter.cs
@@ -67,23 +67,11 @@ public class LinkObjectConverter : JsonConverter<LinkObject>
 	/// <returns>true if the value is boolean true; otherwise, null.</returns>
 	private static bool? TryGetBooleanAsTrue(JsonNode? node)
     {
-        if (node == null)
-        {
-            return null;
-        }
-
         // Per HAL spec: templated should only be true if the value is boolean true
         // Any other value (including boolean false, strings, numbers, objects, arrays) should be treated as false (null)
-        try
-        {
-            var value = node.GetValue<bool>();
+        if (node is JsonValue jv && jv.TryGetValue<bool>(out var value))
             return value ? true : null;
-        }
-        catch
-        {
-            // Not a valid boolean - treat as false (null)
-            return null;
-        }
+        return null;
     }
 
 	/// <summary>
@@ -93,21 +81,10 @@ public class LinkObjectConverter : JsonConverter<LinkObject>
 	/// <returns>The string value, or null if the node is not a valid string.</returns>
 	private static string? TryGetString(JsonNode? node)
     {
-        if (node == null)
-        {
-            return null;
-        }
-
         // Only accept actual string values; reject numbers, booleans, objects, arrays
-        try
-        {
-            return node.GetValue<string>();
-        }
-        catch
-        {
-            // Not a valid string - return null
-            return null;
-        }
+        if (node is JsonValue jv && jv.TryGetValue<string>(out var value))
+            return value;
+        return null;
     }
 
 	/// <summary>

--- a/src/Chatter.Rest.Hal/Converters/ResourceCollectionConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/ResourceCollectionConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
@@ -65,7 +64,7 @@ public class ResourceCollectionConverter : JsonConverter<ResourceCollection>
 	{
 		if (resources.Count == 1)
 		{
-			JsonSerializer.Serialize(writer, resources.First(), options);
+			JsonSerializer.Serialize(writer, resources[0], options);
 		}
 		else
 		{

--- a/src/Chatter.Rest.Hal/Converters/ResourceConverter.cs
+++ b/src/Chatter.Rest.Hal/Converters/ResourceConverter.cs
@@ -56,11 +56,11 @@ public class ResourceConverter : JsonConverter<Resource>
 	{
 		writer.WriteStartObject();
 
-		if (value.StateObject != null)
+		if (value.CachedState != null)
 		{
 			var linksName = options.PropertyNamingPolicy?.ConvertName(nameof(Resource.Links)) ?? nameof(Resource.Links);
 			var embeddedName = options.PropertyNamingPolicy?.ConvertName(nameof(Resource.Embedded)) ?? nameof(Resource.Embedded);
-			var utf8Bytes = JsonSerializer.SerializeToUtf8Bytes(value.StateObject, options);
+			var utf8Bytes = JsonSerializer.SerializeToUtf8Bytes(value.CachedState, options);
 			using var doc = JsonDocument.Parse(utf8Bytes);
 			foreach (var prop in doc.RootElement.EnumerateObject())
 			{

--- a/src/Chatter.Rest.Hal/EmbeddedResourceCollection.cs
+++ b/src/Chatter.Rest.Hal/EmbeddedResourceCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
@@ -13,6 +14,14 @@ namespace Chatter.Rest.Hal;
 public sealed record EmbeddedResourceCollection : ICollection<EmbeddedResource>, IHalPart
 {
 	private readonly Collection<EmbeddedResource> _embedded = new();
+	private readonly Dictionary<string, EmbeddedResource> _index = new(StringComparer.Ordinal);
+
+	/// <summary>
+	/// Gets the embedded resource at the specified index.
+	/// </summary>
+	/// <param name="index">The zero-based index of the embedded resource to get.</param>
+	/// <returns>The embedded resource at the specified index.</returns>
+	public EmbeddedResource this[int index] => _embedded[index];
 
 	/// <summary>
 	/// Gets the number of embedded resources in the collection.
@@ -28,12 +37,20 @@ public sealed record EmbeddedResourceCollection : ICollection<EmbeddedResource>,
 	/// Adds an embedded resource to the collection.
 	/// </summary>
 	/// <param name="item">The embedded resource to add.</param>
-	public void Add(EmbeddedResource item) => _embedded.Add(item);
+	public void Add(EmbeddedResource item)
+	{
+		_embedded.Add(item);
+		_index[item.Name] = item;
+	}
 
 	/// <summary>
 	/// Removes all embedded resources from the collection.
 	/// </summary>
-	public void Clear() => _embedded.Clear();
+	public void Clear()
+	{
+		_embedded.Clear();
+		_index.Clear();
+	}
 
 	/// <summary>
 	/// Determines whether the collection contains a specific embedded resource.
@@ -60,7 +77,22 @@ public sealed record EmbeddedResourceCollection : ICollection<EmbeddedResource>,
 	/// </summary>
 	/// <param name="item">The embedded resource to remove.</param>
 	/// <returns>true if the item was successfully removed; otherwise, false.</returns>
-	public bool Remove(EmbeddedResource item) => _embedded.Remove(item);
+	public bool Remove(EmbeddedResource item)
+	{
+		var removed = _embedded.Remove(item);
+		if (removed)
+			_index.Remove(item.Name);
+		return removed;
+	}
+
+	/// <summary>
+	/// Attempts to retrieve an embedded resource by its name using O(1) dictionary lookup.
+	/// </summary>
+	/// <param name="name">The embedded resource name to find.</param>
+	/// <param name="embedded">When this method returns, contains the embedded resource if found; otherwise, null.</param>
+	/// <returns>true if an embedded resource with the specified name was found; otherwise, false.</returns>
+	public bool TryGetByName(string name, out EmbeddedResource? embedded)
+		=> _index.TryGetValue(name, out embedded);
 
 	/// <summary>
 	/// Returns an enumerator that iterates through the collection.

--- a/src/Chatter.Rest.Hal/Extensions/EmbeddedResourceCollectionExtensions.cs
+++ b/src/Chatter.Rest.Hal/Extensions/EmbeddedResourceCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Chatter.Rest.Hal;
@@ -14,8 +15,8 @@ public static class EmbeddedResourceCollectionExtensions
 	/// <param name="erc">The embedded resource collection to query.</param>
 	/// <param name="name">The name of the embedded resource to find.</param>
 	/// <returns>The embedded resource, or null if not found.</returns>
-	public static EmbeddedResource? GetEmbeddedResource(this EmbeddedResourceCollection erc, string name)
-		=> erc?.SingleOrDefault(er => er.Name.Equals(name));
+	public static EmbeddedResource? GetEmbeddedResource(this EmbeddedResourceCollection? erc, string name)
+		=> erc?.SingleOrDefault(e => e.Name?.Equals(name, StringComparison.Ordinal) == true);
 
 	/// <summary>
 	/// Gets the resource collection from the embedded resource with the specified name.

--- a/src/Chatter.Rest.Hal/Extensions/JsonSerializerOptionsExtensions.cs
+++ b/src/Chatter.Rest.Hal/Extensions/JsonSerializerOptionsExtensions.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Text.Json;
 using Chatter.Rest.Hal.Converters;
 
@@ -27,7 +26,12 @@ public static class JsonSerializerOptionsExtensions
 		this JsonSerializerOptions options,
 		HalJsonOptions? halOptions = null)
 	{
-		if (options.Converters.OfType<LinkCollectionConverter>().Any())
+		var alreadyAdded = false;
+		for (int i = 0; i < options.Converters.Count; i++)
+		{
+			if (options.Converters[i] is LinkCollectionConverter) { alreadyAdded = true; break; }
+		}
+		if (alreadyAdded)
 			return options;
 
 		var resolved = halOptions ?? HalJsonOptions.Default;

--- a/src/Chatter.Rest.Hal/Extensions/LinkCollectionExtensions.cs
+++ b/src/Chatter.Rest.Hal/Extensions/LinkCollectionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Chatter.Rest.Hal;
 
@@ -13,8 +14,8 @@ public static class LinkCollectionExtensions
 	/// <param name="links">The link collection to query.</param>
 	/// <param name="relation">The link relation to find.</param>
 	/// <returns>The link, or null if not found.</returns>
-	public static Link? GetLinkOrDefault(this LinkCollection links, string relation)
-		=> links?.SingleOrDefault(l => l.Rel.Equals(relation));
+	public static Link? GetLinkOrDefault(this LinkCollection? links, string relation)
+		=> links?.SingleOrDefault(l => l.Rel?.Equals(relation, StringComparison.Ordinal) == true);
 
 	/// <summary>
 	/// Gets the collection of link objects for the specified link relation.

--- a/src/Chatter.Rest.Hal/LinkCollection.cs
+++ b/src/Chatter.Rest.Hal/LinkCollection.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Text.Json.Serialization;
@@ -13,6 +14,14 @@ namespace Chatter.Rest.Hal;
 public sealed record LinkCollection : ICollection<Link>, IHalPart
 {
 	private readonly Collection<Link> _links = new();
+	private readonly Dictionary<string, Link> _index = new(StringComparer.Ordinal);
+
+	/// <summary>
+	/// Gets the link at the specified index.
+	/// </summary>
+	/// <param name="index">The zero-based index of the link to get.</param>
+	/// <returns>The link at the specified index.</returns>
+	public Link this[int index] => _links[index];
 
 	/// <summary>
 	/// Gets the number of links in the collection.
@@ -28,12 +37,20 @@ public sealed record LinkCollection : ICollection<Link>, IHalPart
 	/// Adds a link to the collection.
 	/// </summary>
 	/// <param name="item">The link to add.</param>
-	public void Add(Link item) => _links.Add(item);
+	public void Add(Link item)
+	{
+		_links.Add(item);
+		_index[item.Rel] = item;
+	}
 
 	/// <summary>
 	/// Removes all links from the collection.
 	/// </summary>
-	public void Clear() => _links.Clear();
+	public void Clear()
+	{
+		_links.Clear();
+		_index.Clear();
+	}
 
 	/// <summary>
 	/// Determines whether the collection contains a specific link.
@@ -60,7 +77,22 @@ public sealed record LinkCollection : ICollection<Link>, IHalPart
 	/// </summary>
 	/// <param name="item">The link to remove.</param>
 	/// <returns>true if the item was successfully removed; otherwise, false.</returns>
-	public bool Remove(Link item) => _links.Remove(item);
+	public bool Remove(Link item)
+	{
+		var removed = _links.Remove(item);
+		if (removed)
+			_index.Remove(item.Rel);
+		return removed;
+	}
+
+	/// <summary>
+	/// Attempts to retrieve a link by its relation name using O(1) dictionary lookup.
+	/// </summary>
+	/// <param name="rel">The link relation to find.</param>
+	/// <param name="link">When this method returns, contains the link if found; otherwise, null.</param>
+	/// <returns>true if a link with the specified relation was found; otherwise, false.</returns>
+	public bool TryGetByRel(string rel, out Link? link)
+		=> _index.TryGetValue(rel, out link);
 
 	/// <summary>
 	/// Returns an enumerator that iterates through the collection.

--- a/src/Chatter.Rest.Hal/LinkObjectCollection.cs
+++ b/src/Chatter.Rest.Hal/LinkObjectCollection.cs
@@ -15,6 +15,13 @@ public sealed record LinkObjectCollection : ICollection<LinkObject>,  IHalPart
 	private readonly Collection<LinkObject> _linkObjects = new();
 
 	/// <summary>
+	/// Gets the link object at the specified index.
+	/// </summary>
+	/// <param name="index">The zero-based index of the link object to get.</param>
+	/// <returns>The link object at the specified index.</returns>
+	public LinkObject this[int index] => _linkObjects[index];
+
+	/// <summary>
 	/// Gets the number of link objects in the collection.
 	/// </summary>
 	public int Count => _linkObjects.Count;

--- a/src/Chatter.Rest.Hal/Resource.cs
+++ b/src/Chatter.Rest.Hal/Resource.cs
@@ -56,6 +56,16 @@ public sealed record Resource : IHalPart
 		set => _stateObject = value;
 	}
 
+	internal object? CachedState
+	{
+		get
+		{
+			if (_stateObject == null)
+				_stateObject = _stateCreator()?.Deserialize<object>();
+			return _stateObject;
+		}
+	}
+
 	/// <summary>
 	/// Gets or sets the Links collection for this Resource. The collection contains
 	/// link relations and their associated link objects. The getter lazily creates
@@ -67,9 +77,9 @@ public sealed record Resource : IHalPart
 		{
 			if (_linksImpl == null)
 			{
-				_linksImpl = _linksCreator();
+				_linksImpl = _linksCreator() ?? new LinkCollection();
 			}
-			return _linksImpl ?? new LinkCollection();
+			return _linksImpl;
 		}
 		set => _linksImpl = value;
 	}
@@ -84,9 +94,9 @@ public sealed record Resource : IHalPart
 		{
 			if (_embeddedImpl == null)
 			{
-				_embeddedImpl = _embeddedCreator();
+				_embeddedImpl = _embeddedCreator() ?? new EmbeddedResourceCollection();
 			}
-			return _embeddedImpl ?? new EmbeddedResourceCollection();
+			return _embeddedImpl;
 		}
 		set => _embeddedImpl = value;
 	}

--- a/src/Chatter.Rest.Hal/ResourceCollection.cs
+++ b/src/Chatter.Rest.Hal/ResourceCollection.cs
@@ -15,6 +15,13 @@ public sealed record ResourceCollection : ICollection<Resource>, IHalPart
 	private readonly Collection<Resource> _resources = new();
 
 	/// <summary>
+	/// Gets the resource at the specified index.
+	/// </summary>
+	/// <param name="index">The zero-based index of the resource to get.</param>
+	/// <returns>The resource at the specified index.</returns>
+	public Resource this[int index] => _resources[index];
+
+	/// <summary>
 	/// Gets the number of resources in the collection.
 	/// </summary>
 	public int Count => _resources.Count;


### PR DESCRIPTION
## Summary
Implements remaining 8 performance improvements from `docs/performance-todo.md`.

- **PERF-06** (Low-effort/Medium-impact): Add `this[int index]` indexer to 4 collection types; replace LINQ `.First()` with `[0]` in 5 converters — eliminates enumerator boxing on the common single-element path
- **PERF-07** (Low-effort/Medium-impact): Cache fallback empty collection in `Resource.Links`/`Resource.Embedded` getters — eliminates repeated allocation when creator returns null
- **PERF-08** (Low-effort/Medium-impact): Replace `try/catch` + `GetValue<T>()` in `LinkObjectConverter` helpers with `JsonValue.TryGetValue<T>()` — no exception overhead on type mismatches
- **PERF-09** (Low-effort/Medium-impact): Switch source generator from `CreateSyntaxProvider` to `ForAttributeWithMetadataName` — uses Roslyn's internal attribute cache, eliminates per-keystroke semantic analysis. Bumps `Microsoft.CodeAnalysis.CSharp.Workspaces` `4.1.0` → `4.3.1`. Deletes dead `Parser.cs`.
- **PERF-10** (Low-effort/Medium-impact): Move dedup/sort LINQ into a cached `.Select()` transform; introduces `HalClassInfo` struct; removes dead `EnumerableExtensions.cs`
- **PERF-11** (Low-effort/Medium-impact): Add `internal CachedState` property to `Resource` bypassing try/catch; `ResourceConverter.Write` uses it on the hot path
- **PERF-12** (Low-effort/Low-impact): Replace LINQ `.OfType<T>().Any()` guard in `AddHalConverters` with a for-loop
- **PERF-13** (Medium-effort/Low-impact): Add `Dictionary<string,T>` index to `LinkCollection` + `EmbeddedResourceCollection` for O(1) `TryGetByRel`/`TryGetByName` lookup. Extension methods retain `SingleOrDefault` semantics (throws on duplicate rels).

## Test plan
- [x] All 183 tests pass on net8.0 (177 HAL tests + 6 CodeGenerators tests)
- [x] Build clean on both `net8.0` and `netstandard2.0` (0 errors, 2 pre-existing CS8604 warnings)
- [x] No behavior changes — same JSON output, same deserialization results, duplicate-rel throw preserved
- [x] `docs/performance-todo.md` updated — all 13 items now marked complete

## Depends on
PR #55 (`perf/high-impact-fixes`) must merge first — both branches are based on `main` and contain non-overlapping changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)