### PR TITLE
feat: RFC 6570 Level 1 URI template expansion on LinkObject

### DIFF
--- a/docs/HAL_TEST_PLAN.md
+++ b/docs/HAL_TEST_PLAN.md
@@ -147,6 +147,26 @@ A Link Object represents a hyperlink. It MUST have an `href`; all other properti
 ### 3.11 Unknown Link Object properties are ignored (tolerant reader)
 - ✅ `HalLinkAttributesValidationTests.LinkObject_With_Unknown_Properties_Are_Ignored` — verifies unknown properties in Link Object do not cause errors
 
+### 3.12 URI Template expansion (RFC 6570 Level 1)
+> `LinkObject` provides helpers to extract template variables and expand Level 1 URI Templates per RFC 6570. Operator-prefixed expressions (Level 2+) are intentionally left unexpanded.
+
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_SingleVariable_ReturnsList`
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_MultipleVariables_ReturnsList`
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_DuplicateVariables_ReturnsDistinct`
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_NoVariables_ReturnsEmpty`
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_NotTemplated_ReturnsEmpty`
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_TemplatedNull_ReturnsEmpty`
+- ✅ `LinkObjectTemplateExpansionTests.GetTemplateVariables_OperatorPrefixed_NotMatched`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_SingleVariable_Substituted`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_MultipleVariables_AllSubstituted`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_UnresolvedVariable_LeftAsIs`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_EmptyDictionary_HrefUnchanged`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_NotTemplated_ReturnsHrefUnchanged`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_TemplatedNull_ReturnsHrefUnchanged`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_NullVariables_ThrowsArgumentNullException`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_OperatorPrefixed_LeftUnchanged`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_MixedLevel1AndOperator_OnlyLevel1Expanded`
+
 ---
 
 ## 4. `_embedded`
@@ -308,14 +328,14 @@ The fluent builder must produce Resource Objects that conform to the spec.
 |---|---|---|---|---|
 | Resource Object | 5 | 5 | 0 | 0 |
 | `_links` | 7 | 6 | 0 | 1 |
-| Link Objects | 11 | 11 | 0 | 0 |
+| Link Objects | 12 | 12 | 0 | 0 |
 | `_embedded` | 8 | 8 | 0 | 0 |
 | CURIEs | 5 | 5 | 0 | 0 |
 | Normative Rules | 4 | 4 | 0 | 0 |
 | Builder API | 6 | 6 | 0 | 0 |
 | Extension Methods | 5 | 5 | 0 | 0 |
 | Source Generator | 5 | 4 | 0 | 1 |
-| **Total** | **56** | **54** | **0** | **2** |
+| **Total** | **57** | **55** | **0** | **2** |
 
 ---
 

--- a/docs/HAL_TEST_PLAN.md
+++ b/docs/HAL_TEST_PLAN.md
@@ -166,6 +166,11 @@ A Link Object represents a hyperlink. It MUST have an `href`; all other properti
 - ✅ `LinkObjectTemplateExpansionTests.Expand_NullVariables_ThrowsArgumentNullException`
 - ✅ `LinkObjectTemplateExpansionTests.Expand_OperatorPrefixed_LeftUnchanged`
 - ✅ `LinkObjectTemplateExpansionTests.Expand_MixedLevel1AndOperator_OnlyLevel1Expanded`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_ParamsTuple_SingleVariable_Substituted`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_ParamsTuple_MultipleVariables_AllSubstituted`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_ParamsTuple_EmptyParams_HrefUnchanged`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_ParamsTuple_UnresolvedVariable_LeftAsIs`
+- ✅ `LinkObjectTemplateExpansionTests.Expand_ParamsTuple_NotTemplated_ReturnsHrefUnchanged`
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -268,7 +268,68 @@ public interface IEmbeddedLinkObjectPropertiesSelectionStage :
 
 ---
 
-## 9. `Resource` Runtime API
+## 9. `LinkObject` Methods
+
+Namespace: `Chatter.Rest.Hal`
+
+`LinkObject` is a sealed record representing a single HAL link. In addition to its
+[properties](#4-iresourcelinkobjectpropertiesselectionstage) (`Href`, `Templated`,
+`Type`, etc.), it exposes two methods for working with RFC 6570 URI Templates.
+
+### `GetTemplateVariables()`
+
+```csharp
+public IReadOnlyList<string> GetTemplateVariables();
+```
+
+Parses RFC 6570 **Level 1** `{variable}` tokens from `Href` and returns an ordered,
+distinct list of variable names.
+
+- Returns an empty list when `Templated` is not `true`.
+- Returns an empty list when `Href` contains no Level 1 variables.
+- Operator-prefixed expressions (`{+var}`, `{#var}`, `{?query}`, etc.) are **not**
+  matched — only simple `{name}` tokens.
+
+### `Expand(IDictionary<string, string> variables)`
+
+```csharp
+public string Expand(IDictionary<string, string> variables);
+```
+
+Performs RFC 6570 Level 1 simple string expansion on the `Href` URI template.
+
+- Substitutes each `{variable}` whose key exists in the dictionary.
+- **Tolerant reader:** unresolved variables (present in the template but absent from
+  the dictionary) are left as-is, allowing partial expansion.
+- Returns `Href` unchanged when `Templated` is not `true`.
+- Throws `ArgumentNullException` when `variables` is `null`.
+
+### Usage example
+
+```csharp
+var link = new LinkObject("/orders/{id}") { Templated = true };
+
+// Get variable names
+IReadOnlyList<string> vars = link.GetTemplateVariables(); // ["id"]
+
+// Expand to a resolved URI
+string uri = link.Expand(new Dictionary<string, string> { ["id"] = "42" });
+// uri == "/orders/42"
+
+// Partial expansion — unresolved variables are preserved
+var partial = new LinkObject("/search/{term}/page/{page}") { Templated = true };
+string result = partial.Expand(new Dictionary<string, string> { ["term"] = "hal" });
+// result == "/search/hal/page/{page}"
+
+// Non-templated links return Href unchanged
+var plain = new LinkObject("/about");
+string href = plain.Expand(new Dictionary<string, string> { ["id"] = "99" });
+// href == "/about"
+```
+
+---
+
+## 10. `Resource` Runtime API
 
 Namespace: `Chatter.Rest.Hal`
 
@@ -300,7 +361,7 @@ public sealed record Resource : IHalPart
 
 ---
 
-## 10. `ResourceExtensions`
+## 11. `ResourceExtensions`
 
 Namespace: `Chatter.Rest.Hal`
 
@@ -332,7 +393,7 @@ public static class ResourceExtensions
 
 ---
 
-## 11. `LinkCollectionExtensions`
+## 12. `LinkCollectionExtensions`
 
 Namespace: `Chatter.Rest.Hal`
 
@@ -364,7 +425,7 @@ public static class LinkCollectionExtensions
 
 ---
 
-## 12. `LinkObjectCollectionExtensions` and `ResourceCollectionExtensions`
+## 13. `LinkObjectCollectionExtensions` and `ResourceCollectionExtensions`
 
 Namespace: `Chatter.Rest.Hal`
 
@@ -385,7 +446,7 @@ public static class ResourceCollectionExtensions
 
 ---
 
-## 13. `EmbeddedResourceCollectionExtensions`
+## 14. `EmbeddedResourceCollectionExtensions`
 
 Namespace: `Chatter.Rest.Hal`
 
@@ -408,7 +469,7 @@ public static class EmbeddedResourceCollectionExtensions
 
 ---
 
-## 14. Serialization API
+## 15. Serialization API
 
 ### `HalJsonOptions`
 
@@ -463,7 +524,7 @@ HalJsonOptions.Default.AlwaysUseArrayForLinks = true;
 
 ---
 
-## 15. Source Generator: `[HalResponse]`
+## 16. Source Generator: `[HalResponse]`
 
 ### Attribute
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -304,6 +304,18 @@ Performs RFC 6570 Level 1 simple string expansion on the `Href` URI template.
 - Returns `Href` unchanged when `Templated` is not `true`.
 - Throws `ArgumentNullException` when `variables` is `null`.
 
+### `Expand(params (string Key, string Value)[] variables)`
+
+```csharp
+public string Expand(params (string Key, string Value)[] variables);
+```
+
+Ergonomic overload that accepts key-value tuples instead of a dictionary. Delegates
+to `Expand(IDictionary<string, string>)`.
+
+- Same expansion, tolerant-reader, and guard behavior as the dictionary overload.
+- Preferred for call sites where the variables are known at compile time.
+
 ### Usage example
 
 ```csharp
@@ -312,18 +324,25 @@ var link = new LinkObject("/orders/{id}") { Templated = true };
 // Get variable names
 IReadOnlyList<string> vars = link.GetTemplateVariables(); // ["id"]
 
-// Expand to a resolved URI
-string uri = link.Expand(new Dictionary<string, string> { ["id"] = "42" });
+// params tuple syntax (preferred)
+string uri = link.Expand(("id", "42"));
 // uri == "/orders/42"
+
+// multiple variables
+string uri2 = link.Expand(("orderId", "9001"), ("itemId", "3"));
+
+// dictionary syntax (for dynamic/runtime variable sets)
+var dict = new Dictionary<string, string> { ["id"] = "42" };
+string uri3 = link.Expand(dict);
 
 // Partial expansion — unresolved variables are preserved
 var partial = new LinkObject("/search/{term}/page/{page}") { Templated = true };
-string result = partial.Expand(new Dictionary<string, string> { ["term"] = "hal" });
+string result = partial.Expand(("term", "hal"));
 // result == "/search/hal/page/{page}"
 
 // Non-templated links return Href unchanged
 var plain = new LinkObject("/about");
-string href = plain.Expand(new Dictionary<string, string> { ["id"] = "99" });
+string href = plain.Expand(("id", "99"));
 // href == "/about"
 ```
 

--- a/src/Chatter.Rest.Hal/LinkObject.cs
+++ b/src/Chatter.Rest.Hal/LinkObject.cs
@@ -1,5 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using Chatter.Rest.Hal.Converters;
 
 namespace Chatter.Rest.Hal;
@@ -151,4 +154,84 @@ public sealed record LinkObject : IHalPart
 	/// the target resource(as defined by [RFC5988]).
 	/// </remarks>
 	public string? Hreflang { get; set; }
+
+	/// <summary>
+	/// Parses RFC 6570 Level 1 template variable names from <see cref="Href"/>.
+	/// </summary>
+	/// <returns>
+	/// An ordered, distinct list of variable names found in <c>{variable}</c> tokens.
+	/// Returns an empty list when <see cref="Href"/> contains no template variables
+	/// or when <see cref="Templated"/> is not <c>true</c>.
+	/// </returns>
+	/// <remarks>
+	/// Only RFC 6570 Level 1 simple string expansion is supported.
+	/// Operator-prefixed expressions (<c>{+var}</c>, <c>{#var}</c>, etc.) are not matched.
+	/// </remarks>
+	public IReadOnlyList<string> GetTemplateVariables()
+	{
+		if (Templated != true)
+		{
+			return Array.Empty<string>();
+		}
+
+		var matches = Regex.Matches(Href, @"\{([A-Za-z0-9_]+)\}");
+		var variables = new List<string>();
+		var seen = new HashSet<string>(StringComparer.Ordinal);
+
+		foreach (Match match in matches)
+		{
+			var name = match.Groups[1].Value;
+			if (seen.Add(name))
+			{
+				variables.Add(name);
+			}
+		}
+
+		return variables;
+	}
+
+	/// <summary>
+	/// Performs RFC 6570 Level 1 simple string expansion on the <see cref="Href"/> URI template.
+	/// </summary>
+	/// <param name="variables">
+	/// A dictionary mapping variable names to their substitution values.
+	/// Keys are case-sensitive and must match template variable names exactly.
+	/// </param>
+	/// <returns>
+	/// The resolved URI with matched variables substituted. Unresolved variables
+	/// (present in the template but absent from <paramref name="variables"/>) are
+	/// left as-is (e.g., <c>{id}</c> remains <c>{id}</c>). When <see cref="Templated"/>
+	/// is not <c>true</c> or <see cref="Href"/> is null or empty, returns <see cref="Href"/> unchanged.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">
+	/// Thrown when <paramref name="variables"/> is null.
+	/// </exception>
+	/// <remarks>
+	/// <para>
+	/// This method implements the tolerant reader pattern: unresolved variables are preserved
+	/// rather than throwing, allowing partial expansion when only some variables are known.
+	/// </para>
+	/// <para>
+	/// Only RFC 6570 Level 1 simple string expansion is supported. Operator-prefixed
+	/// expressions (<c>{+var}</c>, <c>{#var}</c>, etc.) are left unchanged.
+	/// </para>
+	/// </remarks>
+	public string Expand(IDictionary<string, string> variables)
+	{
+		if (variables == null)
+		{
+			throw new ArgumentNullException(nameof(variables));
+		}
+
+		if (Templated != true || string.IsNullOrEmpty(Href))
+		{
+			return Href;
+		}
+
+		return Regex.Replace(Href, @"\{([A-Za-z0-9_]+)\}", match =>
+		{
+			var name = match.Groups[1].Value;
+			return variables.TryGetValue(name, out var value) ? value : match.Value;
+		});
+	}
 }

--- a/src/Chatter.Rest.Hal/LinkObject.cs
+++ b/src/Chatter.Rest.Hal/LinkObject.cs
@@ -234,4 +234,29 @@ public sealed record LinkObject : IHalPart
 			return variables.TryGetValue(name, out var value) ? value : match.Value;
 		});
 	}
+
+	/// <summary>
+	/// Performs RFC 6570 Level 1 simple string expansion using the provided key-value pairs.
+	/// </summary>
+	/// <param name="variables">
+	/// Variable name and value pairs to substitute into the URI template.
+	/// Each element's <c>Key</c> is the variable name; <c>Value</c> is the substitution value.
+	/// </param>
+	/// <returns>
+	/// The resolved URI with matched variables substituted. When <see cref="Templated"/>
+	/// is not <c>true</c> or <see cref="Href"/> is null or empty, returns <see cref="Href"/> unchanged.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">
+	/// Thrown when <paramref name="variables"/> is null.
+	/// </exception>
+	/// <remarks>
+	/// This overload delegates to <see cref="Expand(IDictionary{string,string})"/>.
+	/// Unresolved variables are preserved (tolerant reader pattern).
+	/// Only RFC 6570 Level 1 simple string expansion is supported.
+	/// </remarks>
+	public string Expand(params (string Key, string Value)[] variables)
+	{
+		if (variables is null) throw new ArgumentNullException(nameof(variables));
+		return Expand(variables.ToDictionary(kv => kv.Key, kv => kv.Value));
+	}
 }

--- a/test/Chatter.Rest.Hal.Tests/LinkObjectTemplateExpansionTests.cs
+++ b/test/Chatter.Rest.Hal.Tests/LinkObjectTemplateExpansionTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Xunit;
+
+namespace Chatter.Rest.Hal.Tests;
+
+public class LinkObjectTemplateExpansionTests
+{
+	[Fact]
+	public void GetTemplateVariables_SingleVariable_ReturnsList()
+	{
+		var lo = new LinkObject("/items/{id}") { Templated = true };
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().Equal("id");
+	}
+
+	[Fact]
+	public void GetTemplateVariables_MultipleVariables_ReturnsList()
+	{
+		var lo = new LinkObject("/items/{id}/details/{section}") { Templated = true };
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().Equal("id", "section");
+	}
+
+	[Fact]
+	public void GetTemplateVariables_DuplicateVariables_ReturnsDistinct()
+	{
+		var lo = new LinkObject("/items/{id}/related/{id}") { Templated = true };
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().Equal("id");
+	}
+
+	[Fact]
+	public void GetTemplateVariables_NoVariables_ReturnsEmpty()
+	{
+		var lo = new LinkObject("/items/42") { Templated = true };
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetTemplateVariables_NotTemplated_ReturnsEmpty()
+	{
+		var lo = new LinkObject("/items/{id}") { Templated = false };
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetTemplateVariables_TemplatedNull_ReturnsEmpty()
+	{
+		var lo = new LinkObject("/items/{id}");
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void GetTemplateVariables_OperatorPrefixed_NotMatched()
+	{
+		var lo = new LinkObject("/items/{+path}") { Templated = true };
+
+		var variables = lo.GetTemplateVariables();
+
+		variables.Should().BeEmpty();
+	}
+
+	[Fact]
+	public void Expand_SingleVariable_Substituted()
+	{
+		var lo = new LinkObject("/items/{id}") { Templated = true };
+
+		var result = lo.Expand(new Dictionary<string, string> { { "id", "42" } });
+
+		result.Should().Be("/items/42");
+	}
+
+	[Fact]
+	public void Expand_MultipleVariables_AllSubstituted()
+	{
+		var lo = new LinkObject("/items/{id}/details/{section}") { Templated = true };
+
+		var result = lo.Expand(new Dictionary<string, string>
+		{
+			{ "id", "42" },
+			{ "section", "specs" }
+		});
+
+		result.Should().Be("/items/42/details/specs");
+	}
+
+	[Fact]
+	public void Expand_UnresolvedVariable_LeftAsIs()
+	{
+		var lo = new LinkObject("/items/{id}/details/{section}") { Templated = true };
+
+		var result = lo.Expand(new Dictionary<string, string> { { "id", "42" } });
+
+		result.Should().Be("/items/42/details/{section}");
+	}
+
+	[Fact]
+	public void Expand_EmptyDictionary_HrefUnchanged()
+	{
+		var lo = new LinkObject("/items/{id}") { Templated = true };
+
+		var result = lo.Expand(new Dictionary<string, string>());
+
+		result.Should().Be("/items/{id}");
+	}
+
+	[Fact]
+	public void Expand_NotTemplated_ReturnsHrefUnchanged()
+	{
+		var lo = new LinkObject("/items/{id}") { Templated = false };
+
+		var result = lo.Expand(new Dictionary<string, string> { { "id", "42" } });
+
+		result.Should().Be("/items/{id}");
+	}
+
+	[Fact]
+	public void Expand_TemplatedNull_ReturnsHrefUnchanged()
+	{
+		var lo = new LinkObject("/items/{id}");
+
+		var result = lo.Expand(new Dictionary<string, string> { { "id", "42" } });
+
+		result.Should().Be("/items/{id}");
+	}
+
+	[Fact]
+	public void Expand_NullVariables_ThrowsArgumentNullException()
+	{
+		var lo = new LinkObject("/items/{id}") { Templated = true };
+
+		Action act = () => lo.Expand(null!);
+
+		act.Should().Throw<ArgumentNullException>();
+	}
+
+	[Fact]
+	public void Expand_OperatorPrefixed_LeftUnchanged()
+	{
+		var lo = new LinkObject("/search{?query,page}") { Templated = true };
+
+		var result = lo.Expand(new Dictionary<string, string>
+		{
+			{ "query", "test" },
+			{ "page", "1" }
+		});
+
+		result.Should().Be("/search{?query,page}");
+	}
+
+	[Fact]
+	public void Expand_MixedLevel1AndOperator_OnlyLevel1Expanded()
+	{
+		var lo = new LinkObject("/items/{id}{?expand}") { Templated = true };
+
+		var result = lo.Expand(new Dictionary<string, string>
+		{
+			{ "id", "42" },
+			{ "expand", "all" }
+		});
+
+		result.Should().Be("/items/42{?expand}");
+	}
+}

--- a/test/Chatter.Rest.Hal.Tests/LinkObjectTemplateExpansionTests.cs
+++ b/test/Chatter.Rest.Hal.Tests/LinkObjectTemplateExpansionTests.cs
@@ -146,7 +146,7 @@ public class LinkObjectTemplateExpansionTests
 	{
 		var lo = new LinkObject("/items/{id}") { Templated = true };
 
-		Action act = () => lo.Expand(null!);
+		Action act = () => lo.Expand((IDictionary<string, string>)null!);
 
 		act.Should().Throw<ArgumentNullException>();
 	}
@@ -177,5 +177,55 @@ public class LinkObjectTemplateExpansionTests
 		});
 
 		result.Should().Be("/items/42{?expand}");
+	}
+
+	[Fact]
+	public void Expand_ParamsTuple_SingleVariable_Substituted()
+	{
+		var lo = new LinkObject("/orders/{id}") { Templated = true };
+
+		var result = lo.Expand(("id", "9001"));
+
+		result.Should().Be("/orders/9001");
+	}
+
+	[Fact]
+	public void Expand_ParamsTuple_MultipleVariables_AllSubstituted()
+	{
+		var lo = new LinkObject("/orders/{orderId}/items/{itemId}") { Templated = true };
+
+		var result = lo.Expand(("orderId", "9001"), ("itemId", "3"));
+
+		result.Should().Be("/orders/9001/items/3");
+	}
+
+	[Fact]
+	public void Expand_ParamsTuple_EmptyParams_HrefUnchanged()
+	{
+		var lo = new LinkObject("/orders/{id}") { Templated = true };
+
+		var result = lo.Expand();
+
+		result.Should().Be("/orders/{id}");
+	}
+
+	[Fact]
+	public void Expand_ParamsTuple_UnresolvedVariable_LeftAsIs()
+	{
+		var lo = new LinkObject("/orders/{orderId}/items/{itemId}") { Templated = true };
+
+		var result = lo.Expand(("orderId", "9001"));
+
+		result.Should().Be("/orders/9001/items/{itemId}");
+	}
+
+	[Fact]
+	public void Expand_ParamsTuple_NotTemplated_ReturnsHrefUnchanged()
+	{
+		var lo = new LinkObject("/orders/{id}") { Templated = false };
+
+		var result = lo.Expand(("id", "9001"));
+
+		result.Should().Be("/orders/{id}");
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `GetTemplateVariables()` to `LinkObject` — parses `{variable}` tokens from `Href`, returns distinct ordered list; returns empty when `Templated != true`
- Adds `Expand(IDictionary<string, string> variables)` to `LinkObject` — RFC 6570 Level 1 simple string substitution; unresolved variables preserved (tolerant reader); throws `ArgumentNullException` for null input; no-op when `Templated != true`
- Operator-prefixed expressions (`{+var}`, `{?q}`, `{#frag}`, etc.) are excluded by design — Level 2+ not supported
- No new NuGet dependencies; compatible with `netstandard2.0` and `net8.0`

## Implements

`IDEA-01` from the feature backlog. Foundational dependency for future MCP (`IDEA-02`) and HTTP client (`IDEA-04`) work.

## Test plan

- [ ] 16 new tests in `LinkObjectTemplateExpansionTests` — all passing (193 total, 0 failures)
- [ ] Covers: single/multiple/duplicate variables, no variables, `Templated=false/null` guards, operator-prefixed exclusion, partial expansion (tolerant reader), empty dict, null argument, mixed Level 1 + Level 2+ expressions
- [ ] Both TFMs build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)