### PR TITLE
chore: bump Chatter.Rest.Hal version to 1.0.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ See [docs/development.md](docs/development.md) for CI/CD workflow details.
 
 ## Package Versions
 
-- `Chatter.Rest.Hal` — v1.0.0
+- `Chatter.Rest.Hal` — v1.0.1
 - `Chatter.Rest.Hal.CodeGenerators` — v0.3.0
 - `Chatter.Rest.UriTemplates` — v0.1.0
 

--- a/src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
+++ b/src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A dotnet/c# implementation of the Hypertext Application Language (HAL+json) specification for RESTful Web Apis</Description>


### PR DESCRIPTION
## Summary
- Bumps `Chatter.Rest.Hal` NuGet package version from `1.0.0` to `1.0.1`
- Updates version reference in `CLAUDE.md`

## Test plan
- [ ] Verify `dotnet build` succeeds
- [ ] Verify NuGet package version shows `1.0.1` after pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)