### PR TITLE
docs(mcp): add requirements and architecture for Chatter.Rest.Hal.Mcp

### DIFF
--- a/docs/mcp/architecture.md
+++ b/docs/mcp/architecture.md
@@ -1,0 +1,493 @@
+# Chatter.Rest.Hal.Mcp -- Technical Architecture
+
+This document is the source of truth for how the `Chatter.Rest.Hal.Mcp` package is built. It guides implementation decisions with enough detail for a developer to implement each type without ambiguity. For what the system does, see [requirements.md](requirements.md).
+
+---
+
+## Prerequisites
+
+IDEA-04 (`Chatter.Rest.Hal.Client`) must be implemented before this package. It provides `HttpClient` extension methods (notably `GetHalAsync`) that this package uses to fetch and parse HAL resources over HTTP. See [docs/backlog.md](../backlog.md) for the IDEA-04 specification.
+
+---
+
+## Package Dependency Graph
+
+```
+Chatter.Rest.Hal.Mcp
+  -> Chatter.Rest.Hal.Client   (IDEA-04; provides GetHalAsync)
+  -> ModelContextProtocol       (Microsoft official C# MCP SDK)
+      -> Chatter.Rest.Hal       (core types: Resource, LinkObject, LinkCollection, Link)
+```
+
+`Chatter.Rest.Hal.Client` itself depends on `Chatter.Rest.Hal` and `System.Net.Http`. The MCP package does not reference `System.Net.Http` directly -- all HTTP access flows through `Chatter.Rest.Hal.Client`.
+
+---
+
+## SDK Alignment
+
+The package integrates with `ModelContextProtocol` (Microsoft's official C# MCP SDK) using the same patterns as the `dotnet new mcpserver` template:
+
+- **Tool registration:** Tools are registered via an `IMcpServerBuilder` extension method (`WithHalApi`), following the same DI seam as `WithToolsFromAssembly()`.
+- **Tool base class:** All tool instances (both HAL-derived and static) extend `McpServerTool` abstract base.
+- **Dynamic tool collection:** `McpServerPrimitiveCollection<McpServerTool>` (accessed via `McpServerOptions.ToolCollection`) is mutated at runtime. The SDK auto-fires `tools/list_changed` when the collection's `Changed` event triggers.
+- **No custom handlers:** No custom `ListToolsHandler` or `CallToolHandler` is needed. Standard collection mutation and `McpServerTool.InvokeAsync` dispatch suffice.
+
+---
+
+## Project Location
+
+- Source: `src/Chatter.Rest.Hal.Mcp/`
+- Tests: `test/Chatter.Rest.Hal.Mcp.Tests/`
+
+---
+
+## Namespaces
+
+| Namespace | Visibility | Contents |
+|---|---|---|
+| `Chatter.Rest.Hal.Mcp` | Public | `HalMcpServerOptions`, `HalNavigationTool`, `NavigateToRootTool`, `HalMcpServerBuilderExtensions` |
+| `Chatter.Rest.Hal.Mcp.Internal` | Internal | `HalToolCollectionManager`, `ToolNaming` |
+
+---
+
+## Key Types
+
+### `HalMcpServerOptions`
+
+Configuration object for the MCP-HAL bridge. Registered as a singleton via the options pattern.
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp;
+
+public sealed class HalMcpServerOptions
+{
+    /// <summary>
+    /// The root URI of the HAL API. Required. Fetched on startup and when the
+    /// agent calls navigate_to_root.
+    /// </summary>
+    public string RootUri { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Link relations that are not converted to tools. Default: ["curies"].
+    /// </summary>
+    public ISet<string> ExcludeRels { get; set; } = new HashSet<string> { "curies" };
+}
+```
+
+**Validation:** `RootUri` is validated during `WithHalApi` registration. If null, empty, or whitespace, `ArgumentException` is thrown immediately (REQ-19).
+
+---
+
+### `HalNavigationTool : McpServerTool`
+
+Wraps a single `LinkObject` and its relation name. One instance per non-excluded rel in the current resource's `_links`.
+
+**Constructor:**
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp;
+
+public sealed class HalNavigationTool : McpServerTool
+{
+    public HalNavigationTool(
+        string rel,
+        LinkObject link,
+        string selfHref,
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        McpServerOptions mcpOptions);
+}
+```
+
+**Fields stored:**
+- `_rel` -- the link relation name
+- `_link` -- the `LinkObject` instance
+- `_selfHref` -- the self href of the resource this link came from (used for tool naming)
+- `_httpClient` -- the `HttpClient` for fetching
+- `_halOptions` -- configuration
+- `_mcpOptions` -- access to `McpServerOptions.ToolCollection`
+
+**`ProtocolTool` property (override):**
+
+Built from:
+- `Name` = `ToolNaming.CreateToolName(selfHref, rel)`
+- `Description` = `link.Title ?? $"Navigate to {rel}"`
+- `InputSchema` = JSON Schema with one `string` property per template variable from `link.GetTemplateVariables()`. Non-templated links produce `{ "type": "object", "properties": {} }`.
+
+Example input schema for `href="/orders/{id}"`:
+```json
+{
+    "type": "object",
+    "properties": {
+        "id": { "type": "string" }
+    },
+    "required": ["id"]
+}
+```
+
+**`InvokeAsync` method:** See [InvokeAsync Flow](#invokeasync-flow-halnavigationtool) below.
+
+---
+
+### `NavigateToRootTool : McpServerTool`
+
+Persistent static tool that is never removed from the tool collection.
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp;
+
+public sealed class NavigateToRootTool : McpServerTool
+{
+    public NavigateToRootTool(
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        McpServerOptions mcpOptions);
+}
+```
+
+**`ProtocolTool` property:**
+- `Name` = `"navigate_to_root"`
+- `Description` = `"Return to the API root and rediscover available actions"`
+- `InputSchema` = `{ "type": "object", "properties": {} }` (no input parameters)
+
+**`InvokeAsync`:**
+1. Fetch `halOptions.RootUri` via `httpClient.GetHalAsync(halOptions.RootUri)`
+2. If response is `null`: return `CallToolResult { IsError = true }` with message `$"Response from {halOptions.RootUri} was not a valid HAL resource"`
+3. Call `HalToolCollectionManager.SwapTools(mcpOptions.ToolCollection, response, halOptions.RootUri, halOptions, httpClient, mcpOptions)`
+4. Serialize response to HAL JSON
+5. Return `CallToolResult { Content = [new TextContentBlock { Text = json }] }`
+6. Exception catch-all: return `CallToolResult { IsError = true, Content = [ex.Message] }`
+
+---
+
+### `HalToolCollectionManager` (internal static)
+
+Central logic for replacing the tool collection with tools derived from a HAL resource's links.
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp.Internal;
+
+internal static class HalToolCollectionManager
+{
+    public static void SwapTools(
+        McpServerPrimitiveCollection<McpServerTool> collection,
+        Resource resource,
+        string selfHref,
+        HalMcpServerOptions halOptions,
+        HttpClient httpClient,
+        McpServerOptions mcpOptions);
+}
+```
+
+See [Tool Collection Swap Algorithm](#tool-collection-swap-algorithm) below.
+
+---
+
+### `ToolNaming` (internal static)
+
+Pure function for deriving MCP tool names from HAL self href and rel.
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp.Internal;
+
+internal static class ToolNaming
+{
+    public static string CreateToolName(string selfHref, string rel);
+}
+```
+
+See [Tool Naming Algorithm](#tool-naming-algorithm) below.
+
+---
+
+### `HalMcpStartupService : IHostedService`
+
+Hosted service that fetches the root resource on startup and populates the initial tool collection.
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp;
+
+public sealed class HalMcpStartupService : IHostedService
+{
+    public HalMcpStartupService(
+        McpServerOptions mcpOptions,
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions);
+
+    public Task StartAsync(CancellationToken cancellationToken);
+    public Task StopAsync(CancellationToken cancellationToken);
+}
+```
+
+**`StartAsync`:**
+1. Fetch `halOptions.RootUri` via `httpClient.GetHalAsync(halOptions.RootUri)`
+2. If successful: call `HalToolCollectionManager.SwapTools(...)` to populate tool collection with root's links
+3. If fetch fails (any exception or null response): catch, log warning, do not throw. The `navigate_to_root` tool (already in the collection from registration) remains available for the agent to retry.
+
+**`StopAsync`:** No-op. Returns `Task.CompletedTask`.
+
+---
+
+### `HalMcpServerBuilderExtensions`
+
+The single public entry point for wiring HAL-MCP integration into the DI container.
+
+```csharp
+namespace Chatter.Rest.Hal.Mcp;
+
+public static class HalMcpServerBuilderExtensions
+{
+    public static IMcpServerBuilder WithHalApi(
+        this IMcpServerBuilder builder,
+        Action<HalMcpServerOptions> configure);
+}
+```
+
+**Registration sequence:**
+1. Create `HalMcpServerOptions` instance, invoke `configure` delegate
+2. Validate `RootUri` is not null/empty/whitespace; throw `ArgumentException` if invalid (REQ-19)
+3. Register `HalMcpServerOptions` as singleton
+4. Create `NavigateToRootTool` singleton and add it to `McpServerOptions.ToolCollection`
+5. Register `HalMcpStartupService` as `IHostedService`
+6. Return `builder` for chaining
+
+---
+
+## Tool Naming Algorithm
+
+```
+ToolNaming.CreateToolName(selfHref, rel):
+    segment = selfHref
+        .TrimStart('/')
+        .Replace('/', '_')
+        .Replace('{', '_')
+        .Replace('}', '_')
+        .Replace('-', '_')
+        .ToLowerInvariant()
+    prefix = segment == "" ? "root" : segment
+    return $"{prefix}__{rel}"
+```
+
+### Examples
+
+| selfHref | rel | tool name |
+|---|---|---|
+| `/` | `orders` | `root__orders` |
+| `/orders/42` | `cancel` | `orders_42__cancel` |
+| `/api/v1/customers` | `next` | `api_v1_customers__next` |
+| `/orders/{id}` | `self` | `orders__id___self` |
+| `/user-profiles` | `search` | `user_profiles__search` |
+| `/` | `self` | `root__self` |
+| `/api/v2/users/abc-def` | `edit` | `api_v2_users_abc_def__edit` |
+
+The double-underscore `__` separator between prefix and rel is intentional. Single underscores appear within the sanitized href segments, so the double underscore provides unambiguous parsing of prefix vs. rel.
+
+---
+
+## Tool Collection Swap Algorithm
+
+```
+SwapTools(collection, resource, selfHref, halOptions, httpClient, mcpOptions):
+    // 1. Preserve navigate_to_root
+    navigateToRoot = collection entries where tool name == "navigate_to_root"
+
+    // 2. Clear and restore persistent tools
+    collection.Clear()
+    for each tool in navigateToRoot:
+        collection.Add(tool)
+
+    // 3. Resolve actual self href from the resource if available
+    effectiveSelf = selfHref
+    if resource.Links is not null:
+        for each link in resource.Links:
+            if link.Rel == "self" and link.LinkObjects has entries:
+                effectiveSelf = link.LinkObjects[0].Href
+                break
+
+    // 4. Add one HalNavigationTool per non-excluded rel
+    if resource.Links is not null:
+        for each link in resource.Links:
+            if link.Rel in halOptions.ExcludeRels:
+                continue
+            linkObject = link.LinkObjects[0]  // first LinkObject only (v1)
+            collection.Add(new HalNavigationTool(
+                link.Rel, linkObject, effectiveSelf,
+                httpClient, halOptions, mcpOptions))
+
+    // 5. collection.Changed fires automatically
+    //    -> SDK sends tools/list_changed notification
+```
+
+**Key behaviors:**
+- `navigate_to_root` is always preserved (REQ-02)
+- Self href is resolved from the resource's own `self` link when available, falling back to the provided `selfHref` parameter
+- Only the first `LinkObject` per rel is used (REQ-04); array relations are not expanded in v1
+- Rels in `ExcludeRels` are skipped (REQ-17)
+- The `self` rel is included by default unless explicitly excluded (REQ-18)
+
+---
+
+## InvokeAsync Flow (HalNavigationTool)
+
+```
+InvokeAsync(request, cancellationToken):
+    try:
+        // 1. Extract arguments
+        args = request.Params?.Arguments as IDictionary<string, string>
+            ?? empty dictionary
+
+        // 2. Resolve href
+        if _link.Templated == true:
+            resolvedHref = _link.Expand(args)
+        else:
+            resolvedHref = _link.Href
+
+        // 3. Fetch resource
+        response = await _httpClient.GetHalAsync(resolvedHref)
+
+        // 4. Handle non-HAL response
+        if response is null:
+            return CallToolResult
+            {
+                IsError = true,
+                Content = [TextContentBlock("Response from {resolvedHref} was not a valid HAL resource")]
+            }
+
+        // 5. Swap tool collection with new resource's links
+        HalToolCollectionManager.SwapTools(
+            _mcpOptions.ToolCollection, response, resolvedHref,
+            _halOptions, _httpClient, _mcpOptions)
+
+        // 6. Serialize response to HAL JSON
+        json = JsonSerializer.Serialize(response, halJsonSerializerOptions)
+
+        // 7. Return content
+        return CallToolResult
+        {
+            Content = [TextContentBlock(json)]
+        }
+
+    catch HttpRequestException ex when status code available:
+        return CallToolResult
+        {
+            IsError = true,
+            Content = [TextContentBlock("HTTP {(int)status} {reason}: {resolvedHref}")]
+        }
+
+    catch Exception ex:
+        return CallToolResult
+        {
+            IsError = true,
+            Content = [TextContentBlock(ex.Message)]
+        }
+```
+
+**Important:** `InvokeAsync` never throws (REQ-14, REQ-15, REQ-16). All failures are returned as `CallToolResult { IsError = true }`.
+
+**Tool collection update on error:** When the HTTP request fails or the response is not HAL, the tool collection is NOT modified. The agent retains its current set of tools and can retry or navigate elsewhere.
+
+---
+
+## Error Handling Summary
+
+| Condition | Behavior | Error message format |
+|---|---|---|
+| HTTP non-success status | `IsError = true`, no collection change | `"HTTP {statusCode} {reasonPhrase}: {resolvedHref}"` |
+| Response is not valid HAL | `IsError = true`, no collection change | `"Response from {resolvedHref} was not a valid HAL resource"` |
+| Exception during invocation | `IsError = true`, no collection change | `ex.Message` |
+| Startup root fetch failure | Logged warning, no throw | `navigate_to_root` remains; agent can retry |
+
+---
+
+## Input Schema Construction
+
+For a `LinkObject` with `Templated == true`, the input schema is built from `LinkObject.GetTemplateVariables()`:
+
+```csharp
+BuildInputSchema(LinkObject link):
+    variables = link.GetTemplateVariables()  // IReadOnlyList<string>
+    if variables.Count == 0:
+        return { "type": "object", "properties": {} }
+
+    properties = {}
+    required = []
+    for each varName in variables:
+        properties[varName] = { "type": "string" }
+        required.Add(varName)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required
+    }
+```
+
+All template variables are typed as `string` in v1 (REQ-07). The `required` array includes all variables -- the agent must supply values for all template parameters.
+
+---
+
+## Serialization
+
+When returning HAL resource content in `CallToolResult`, the resource is serialized using `System.Text.Json.JsonSerializer.Serialize<Resource>()` with HAL converters applied (via `JsonSerializerOptions.AddHalConverters()`). This produces standard HAL JSON including `_links`, `_embedded`, and state properties.
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+**`ToolNaming.CreateToolName`** -- pure function, exhaustive input/output table:
+- Root `/` with various rels
+- Multi-segment paths
+- Paths with template variables (`{id}`)
+- Paths with hyphens
+- Edge cases: trailing slashes, double slashes, empty rel
+
+**`HalToolCollectionManager.SwapTools`** -- core swap logic:
+- Replaces all tools except `navigate_to_root`
+- Excludes rels in `ExcludeRels`
+- Includes `self` by default
+- Preserves `navigate_to_root` after swap
+- Uses resource's self link href when available
+- Falls back to provided selfHref when resource has no self link
+- Handles resource with empty `_links`
+- Handles resource with null `Links`
+
+**`HalNavigationTool.ProtocolTool`** -- property construction:
+- Tool name matches naming algorithm
+- Description uses `Title` when present
+- Description falls back to `"Navigate to {rel}"` when `Title` is null/empty
+- Input schema has correct properties for templated links
+- Input schema is empty for non-templated links
+
+**`HalNavigationTool.InvokeAsync`** -- invocation behavior:
+- Resolves templated href with supplied arguments
+- Uses `Href` directly for non-templated links
+- Returns HAL JSON content on success
+- Swaps tool collection on success
+- Returns `IsError = true` for null response (non-HAL)
+- Returns `IsError = true` for HTTP failure
+- Returns `IsError = true` for exceptions
+- Does not modify tool collection on error
+
+**`NavigateToRootTool.InvokeAsync`** -- root navigation:
+- Fetches configured `RootUri`
+- Resets tool collection to root's links
+- Preserves itself in collection after reset
+- Returns root HAL JSON as content
+- Returns `IsError = true` on failure
+
+### Integration tests
+
+**`WithHalApi` wiring** -- full DI container integration:
+- Mock `HttpClient` returning HAL JSON
+- Verify `HalMcpServerOptions` is registered as singleton
+- Verify `navigate_to_root` is in tool collection after startup
+- Verify root's links appear as tools after startup
+- Verify startup failure is handled gracefully (no throw)
+- Verify `ArgumentException` on missing `RootUri`
+
+**End-to-end traversal** -- multi-step navigation:
+- Start at root -> navigate to sub-resource -> navigate to child -> return to root
+- Verify tool collection updates correctly at each step
+- Verify content returned at each step matches the fetched resource

--- a/docs/mcp/architecture.md
+++ b/docs/mcp/architecture.md
@@ -259,9 +259,8 @@ public static class HalMcpServerBuilderExtensions
 ToolNaming.CreateToolName(selfHref, rel):
     segment = selfHref
         .TrimStart('/')
+        .Replace each `{varname}` token with just `varname` (strip braces, keep inner name)
         .Replace('/', '_')
-        .Replace('{', '_')
-        .Replace('}', '_')
         .Replace('-', '_')
         .ToLowerInvariant()
     prefix = segment == "" ? "root" : segment
@@ -275,10 +274,13 @@ ToolNaming.CreateToolName(selfHref, rel):
 | `/` | `orders` | `root__orders` |
 | `/orders/42` | `cancel` | `orders_42__cancel` |
 | `/api/v1/customers` | `next` | `api_v1_customers__next` |
-| `/orders/{id}` | `self` | `orders__id___self` |
+| `/orders/{id}` | `self` | `orders_id__self` |
 | `/user-profiles` | `search` | `user_profiles__search` |
 | `/` | `self` | `root__self` |
 | `/api/v2/users/abc-def` | `edit` | `api_v2_users_abc_def__edit` |
+| `/orders/{id}/lines/{lineId}` | `delete` | `orders_id_lines_lineid__delete` |
+
+> **Note:** Template variable tokens (`{varname}`) are replaced as a unit — the inner name is preserved and the braces are dropped. Replacing `{` and `}` individually with `_` would produce trailing underscores in the sanitized prefix (e.g. `orders__id_`) and triple-underscore separators in the final tool name (`orders__id___rel`).
 
 The double-underscore `__` separator between prefix and rel is intentional. Single underscores appear within the sanitized href segments, so the double underscore provides unambiguous parsing of prefix vs. rel.
 
@@ -439,7 +441,8 @@ When returning HAL resource content in `CallToolResult`, the resource is seriali
 **`ToolNaming.CreateToolName`** -- pure function, exhaustive input/output table:
 - Root `/` with various rels
 - Multi-segment paths
-- Paths with template variables (`{id}`)
+- Paths with template variables: `{id}` → inner name preserved, braces dropped (e.g. `/orders/{id}` → `orders_id__rel`)
+- Paths with multiple template variables: `/orders/{id}/lines/{lineId}` → `orders_id_lines_lineid__rel`
 - Paths with hyphens
 - Edge cases: trailing slashes, double slashes, empty rel
 

--- a/docs/mcp/requirements.md
+++ b/docs/mcp/requirements.md
@@ -1,0 +1,238 @@
+# Chatter.Rest.Hal.Mcp -- Requirements
+
+This document is the source of truth for what the `Chatter.Rest.Hal.Mcp` package does. Test scenarios are derived directly from the numbered requirements below. For how the system is built, see [architecture.md](architecture.md).
+
+---
+
+## Overview
+
+`Chatter.Rest.Hal.Mcp` is a new NuGet package that bridges HAL HATEOAS APIs to MCP (Model Context Protocol) tool surfaces. It allows AI agents (Claude, Copilot, etc.) to autonomously navigate HAL APIs by discovering `_links` as MCP tools at runtime -- with zero endpoint pre-configuration.
+
+HAL's `_links` collection and MCP tools are structurally isomorphic:
+
+| HAL concept | MCP concept |
+|---|---|
+| `_links` collection | Available tools |
+| Link relation (`rel`) | Tool name |
+| `href` | Tool action / URI |
+| Templated `href` + variables | Tool input schema |
+| `title` | Tool description |
+| `self` | Current resource URI |
+| `_embedded` | Inline resource content |
+
+The package converts these HAL structures into live MCP tools, updating the tool collection dynamically as the agent traverses from resource to resource.
+
+### Package dependencies
+
+- `Chatter.Rest.Hal.Client` (IDEA-04 in [docs/backlog.md](../backlog.md)) -- provides `GetHalAsync` HTTP helpers
+- `ModelContextProtocol` -- Microsoft's official C# MCP SDK
+- `Chatter.Rest.Hal` -- core HAL types (`Resource`, `LinkObject`, `LinkCollection`, etc.)
+
+### Prerequisite
+
+IDEA-04 (`Chatter.Rest.Hal.Client`) must be implemented before this package. It provides the HTTP client extensions (`GetHalAsync`) that this package uses to fetch and parse HAL resources. See [docs/backlog.md](../backlog.md) for IDEA-04 specification.
+
+---
+
+## Personas
+
+### API owner
+
+Has an existing HAL API and wants to expose it to AI agents with minimal code. Expects a one-liner integration (`WithHalApi(...)`) that makes the API navigable by any MCP-compatible agent without writing tool definitions by hand.
+
+### AI application developer
+
+Building an agent that needs to navigate a HAL API without hard-coding endpoints. Expects the agent to start at the root resource, discover available actions as tools, invoke them, and continue traversing -- all driven by the HAL `_links` the API already provides.
+
+### Library consumer
+
+Already uses `Chatter.Rest.Hal` for building or consuming HAL documents. Wants to add AI agent navigation to an existing application with minimal new dependencies and no changes to existing HAL resource construction.
+
+---
+
+## Functional Requirements
+
+### Startup behavior
+
+**REQ-01:** On server startup, the package fetches the configured root URI and converts its `_links` to MCP tools.
+
+**REQ-02:** A persistent `navigate_to_root` tool is always registered and is never replaced during traversal. It must be present in the tool collection at all times, including before the initial root fetch completes.
+
+**REQ-03:** If the root resource fetch fails on startup (network error, non-HAL response, non-success status code), startup does not throw. The error is captured and logged. The `navigate_to_root` tool remains available so the agent can retry root discovery.
+
+### Tool naming
+
+**REQ-04:** Each `LinkObject` in a resource's `_links` becomes one `McpServerTool` instance. For rels with multiple `LinkObject` entries (array relations), only the first `LinkObject` is converted to a tool in v1.
+
+**REQ-05:** Tool name is derived as `{sanitized_self_href}__{rel}` where sanitization applies the following transforms to the self href in order:
+1. Strip leading `/`
+2. Replace `/` with `_`
+3. Replace `{` with `_`
+4. Replace `}` with `_`
+5. Replace `-` with `_`
+6. Lowercase the result
+7. Map empty string (from root `/`) to `root`
+
+Examples:
+
+| self href | rel | tool name |
+|---|---|---|
+| `/` | `orders` | `root__orders` |
+| `/orders/42` | `cancel` | `orders_42__cancel` |
+| `/api/v1/customers` | `next` | `api_v1_customers__next` |
+| `/orders/{id}` | `self` | `orders__id___self` |
+| `/user-profiles` | `search` | `user_profiles__search` |
+
+**REQ-06:** Tool description is `LinkObject.Title` when present and non-empty; otherwise `"Navigate to {rel}"`.
+
+**REQ-07:** Tool input schema contains one `string` parameter per URI template variable in the link's `Href` (discovered via `LinkObject.GetTemplateVariables()`). Non-templated links have an empty input schema. For example, a link with `href="/orders/{id}"` and `templated=true` produces an input schema with a single `id` property of type `string`.
+
+### Tool invocation
+
+**REQ-08:** When a tool is called, the package resolves the templated href using `LinkObject.Expand(IDictionary<string, string>)` with the agent-supplied arguments. For non-templated links, `Href` is used directly.
+
+**REQ-09:** The resolved URI is fetched via HTTP GET using the configured `HttpClient` (through `Chatter.Rest.Hal.Client`'s `GetHalAsync`).
+
+**REQ-10:** On a successful HAL response, the tool collection is replaced with the new resource's `_links` converted to tools. The `navigate_to_root` tool is preserved across all replacements.
+
+**REQ-11:** Replacing the tool collection triggers the SDK's `tools/list_changed` notification automatically. The package mutates `McpServerPrimitiveCollection<McpServerTool>` (from `McpServerOptions.ToolCollection`); the SDK fires the notification when the collection's `Changed` event triggers. No manual notification code is required.
+
+**REQ-12:** The HAL resource JSON (including `_embedded` if present) is returned as text content in the `CallToolResult`. The content is the full serialized HAL JSON of the fetched resource.
+
+**REQ-13:** The `navigate_to_root` tool fetches the configured root URI, replaces the tool collection with the root resource's links (preserving itself), and returns the root resource as text content in the `CallToolResult`.
+
+### Error handling
+
+**REQ-14:** If the HTTP response is not a valid HAL resource (response parses to `null`), the tool returns `CallToolResult { IsError = true }` with a descriptive message including the resolved URI. The tool does not throw.
+
+**REQ-15:** If the HTTP request fails (non-success status code), the tool returns `CallToolResult { IsError = true }` with the HTTP status code, reason phrase, and resolved URI. The tool does not throw.
+
+**REQ-16:** If an exception occurs during tool invocation (network failure, deserialization error, etc.), the tool returns `CallToolResult { IsError = true }` with the exception message. The tool does not throw.
+
+### Configuration
+
+**REQ-17:** `ExcludeRels` option -- a set of rel names that are not converted to tools. Default value is `["curies"]`.
+
+**REQ-18:** The `self` rel is included by default (agent can re-fetch the current resource). Users may add `"self"` to `ExcludeRels` to suppress it.
+
+**REQ-19:** `RootUri` is required. If `RootUri` is null, empty, or whitespace at configuration time, the package must throw `ArgumentException` during service registration to produce a clear startup failure.
+
+### Scope constraints (v1)
+
+**REQ-20:** Only HTTP GET is supported. No POST, PUT, or DELETE requests are made by any tool.
+
+**REQ-21:** Only stdio MCP transport is supported. HTTP transport (which requires per-session tool collections) is out of scope for v1.
+
+**REQ-22:** CURIE expansion is not performed. CURIE rels appear as their compact form. CURIEs are excluded by default via REQ-17's default `ExcludeRels` containing `"curies"`.
+
+**REQ-23:** `MaxDepth` traversal limiting is not implemented. The agent may traverse indefinitely.
+
+---
+
+## Integration Story
+
+The following shows what a user writes in their `Program.cs` to expose a HAL API as an MCP server:
+
+```csharp
+// User's dotnet new mcpserver project:
+builder.Services.AddHttpClient("hal", c =>
+    c.BaseAddress = new Uri("https://api.example.com/"));
+
+builder.Services.AddMcpServer()
+    .WithStdioServerTransport()
+    .WithHalApi(options =>
+    {
+        options.RootUri = "https://api.example.com/";
+        options.ExcludeRels = ["curies", "self"];  // override default
+    });
+```
+
+Key points:
+- `WithHalApi` is an extension method on `IMcpServerBuilder`, following the same pattern as `WithStdioServerTransport()` and `WithToolsFromAssembly()`
+- `HttpClient` is resolved from DI (standard `IHttpClientFactory` pattern)
+- `HalMcpServerOptions` is configured via the standard `Action<T>` options pattern
+- The user does not register individual tools -- all tools are discovered dynamically from HAL `_links`
+
+---
+
+## Behavioral Scenarios
+
+These scenarios describe end-to-end behavior for test derivation.
+
+### Scenario: Agent discovers root API
+
+1. MCP server starts with `RootUri = "https://api.example.com/"`
+2. Startup fetches `GET https://api.example.com/`
+3. Response is a HAL resource with `_links: { self: { href: "/" }, orders: { href: "/orders" }, customers: { href: "/customers" } }`
+4. Tool collection contains: `navigate_to_root`, `root__self`, `root__orders`, `root__customers`
+5. Each tool has the correct description and empty input schema (no template variables)
+
+### Scenario: Agent navigates to a sub-resource
+
+1. Agent calls tool `root__orders`
+2. Package fetches `GET /orders`
+3. Response has `_links: { self: { href: "/orders" }, find: { href: "/orders/{id}", templated: true }, next: { href: "/orders?page=2" } }`
+4. Tool collection is replaced: `navigate_to_root`, `orders__self`, `orders__find`, `orders__next`
+5. `orders__find` has input schema `{ id: string }`
+6. `CallToolResult` content is the full HAL JSON of the orders resource
+
+### Scenario: Agent uses a templated link
+
+1. Agent calls tool `orders__find` with `{ "id": "42" }`
+2. Package calls `LinkObject.Expand({ "id": "42" })` which resolves to `/orders/42`
+3. Package fetches `GET /orders/42`
+4. Response has `_links: { self: { href: "/orders/42" }, cancel: { href: "/orders/42/cancel" } }`
+5. Tool collection is replaced: `navigate_to_root`, `orders_42__self`, `orders_42__cancel`
+6. `CallToolResult` content is the full HAL JSON of order 42
+
+### Scenario: Agent returns to root
+
+1. From any resource, agent calls `navigate_to_root`
+2. Package fetches `GET https://api.example.com/`
+3. Tool collection is reset to root's links plus `navigate_to_root`
+4. `CallToolResult` content is the root resource HAL JSON
+
+### Scenario: HTTP error during navigation
+
+1. Agent calls a tool that resolves to `/orders/999`
+2. Server responds with `404 Not Found`
+3. Tool returns `CallToolResult { IsError = true }` with message `"HTTP 404 Not Found: /orders/999"`
+4. Tool collection is not modified (previous tools remain)
+
+### Scenario: Non-HAL response
+
+1. Agent calls a tool that resolves to `/health`
+2. Server responds with `200 OK` but body is plain text, not HAL JSON
+3. `GetHalAsync` returns `null`
+4. Tool returns `CallToolResult { IsError = true }` with message `"Response from /health was not a valid HAL resource"`
+5. Tool collection is not modified
+
+### Scenario: Startup failure
+
+1. MCP server starts with `RootUri = "https://api.example.com/"`
+2. Root fetch throws `HttpRequestException` (server unreachable)
+3. Startup catches the exception and logs a warning
+4. Tool collection contains only `navigate_to_root`
+5. Agent can call `navigate_to_root` to retry
+
+### Scenario: Excluded rels
+
+1. Root resource has `_links: { self: { href: "/" }, curies: [...], orders: { href: "/orders" } }`
+2. Default `ExcludeRels` is `["curies"]`
+3. Tool collection contains: `navigate_to_root`, `root__self`, `root__orders`
+4. No tool is created for the `curies` rel
+
+---
+
+## Out of Scope (v1)
+
+The following capabilities are explicitly deferred and must not be implemented in the initial version:
+
+- **HTTP method inference** -- all traversal is GET; no POST/PUT/DELETE
+- **HTTP transport** -- per-session tool collections require HTTP transport support in the SDK; stdio only for v1
+- **CURIE expansion** -- CURIE rels are excluded, not expanded
+- **HAL-FORMS support** -- form-based actions are not converted to tools
+- **MaxDepth traversal cap** -- no limit on how deep the agent can navigate
+- **Tool list union mode** -- no accumulation of tools across traversals; each navigation replaces the tool set
+- **Typed input schemas beyond `string`** -- all template variables are `string` parameters
+- **Array relation expansion** -- rels with multiple `LinkObject` entries use only the first entry (REQ-04)


### PR DESCRIPTION
## Summary

- Adds `docs/mcp/requirements.md` — 23 numbered, testable requirements (REQ-01–REQ-23) covering startup behavior, tool naming, tool invocation, error handling, configuration, and v1 scope constraints; includes 3 personas, 5 behavioral scenarios, and explicit out-of-scope list
- Adds `docs/mcp/architecture.md` — full technical design for `Chatter.Rest.Hal.Mcp` package: 6 key types with constructor signatures and method contracts, tool naming algorithm, tool collection swap algorithm, `InvokeAsync` flow, error handling summary, input schema construction, and test strategy
- Tool naming uses `{varname}` token replacement (braces stripped, inner name kept) to avoid triple-underscore edge case in sanitized self hrefs

## Design decisions captured

- Option A traversal model: tool collection replaced on each navigation, `navigate_to_root` persistent static tool always preserved
- GET-only, stdio transport only (v1 scope)
- `McpServerPrimitiveCollection<McpServerTool>` mutation → SDK auto-fires `tools/list_changed`
- `Chatter.Rest.Hal.Client` (IDEA-04) is a prerequisite and must be implemented first
- Aligned with Microsoft's `dotnet new mcpserver` template and `ModelContextProtocol` SDK patterns

## Test plan

- [ ] Requirements doc reviewed — each REQ is standalone and testable
- [ ] Architecture doc reviewed — type signatures, algorithms, and test strategy are sufficient to drive TDD implementation
- [ ] No existing files modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)