### PR TITLE
docs(client): add requirements and architecture for Chatter.Rest.Hal.Client

### DIFF
--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -1,0 +1,549 @@
+# Chatter.Rest.Hal.Client -- Technical Architecture
+
+This document is the source of truth for how the `Chatter.Rest.Hal.Client` package is built. It guides implementation decisions with enough detail for a developer to implement each type without ambiguity. For what the system does, see [requirements.md](requirements.md).
+
+---
+
+## Package Dependency Graph
+
+```
+Chatter.Rest.Hal.Client
+  -> Chatter.Rest.Hal          (core types: Resource, Resource<T>, LinkObject, LinkCollection, Link)
+  -> Chatter.Rest.UriTemplates (RFC 6570 URI template expansion via LinkObject.Expand())
+  -> System.Net.Http           (no new transitive dependencies beyond this)
+```
+
+---
+
+## Project Location
+
+- Source: `src/Chatter.Rest.Hal.Client/`
+- Tests: `test/Chatter.Rest.Hal.Client.Tests/`
+
+---
+
+## Namespaces
+
+| Namespace | Visibility | Contents |
+|---|---|---|
+| `Chatter.Rest.Hal.Client` | Public | `IHalClient`, `HalClient`, `HalClientOptions`, `HalLinkNotFoundException`, `HalResponseException` |
+| `Chatter.Rest.Hal.Client.Extensions` | Public | Extension methods on `Resource` and `HttpClient` |
+
+---
+
+## Key Types
+
+### `HalClientOptions`
+
+Configuration object for `HalClient`. Supports direct construction and the `IOptions<T>` pattern for DI.
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public sealed class HalClientOptions
+{
+    /// <summary>Default Accept header value. Default: "application/hal+json".</summary>
+    public string MediaType { get; set; } = "application/hal+json";
+
+    /// <summary>
+    /// When true, non-HAL responses (wrong Content-Type) throw HalResponseException.
+    /// When false (default), returns null.
+    /// </summary>
+    public bool StrictContentType { get; set; } = false;
+
+    /// <summary>JsonSerializerOptions used for deserialization. Null = library defaults.</summary>
+    public JsonSerializerOptions? JsonOptions { get; set; }
+}
+```
+
+---
+
+### `IHalClient`
+
+The primary abstraction for HAL HTTP operations. Callers depend on this interface for testability.
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public interface IHalClient
+{
+    Task<Resource?> GetAsync(Uri uri, CancellationToken cancellationToken = default);
+    Task<Resource<T>?> GetAsync<T>(Uri uri, CancellationToken cancellationToken = default);
+    Task<Resource?> PostAsync(Uri uri, object body, CancellationToken cancellationToken = default);
+    Task<Resource?> PostAsync(Uri uri, HttpContent content, CancellationToken cancellationToken = default);
+    Task<Resource?> PutAsync(Uri uri, object body, CancellationToken cancellationToken = default);
+    Task<Resource?> PutAsync(Uri uri, HttpContent content, CancellationToken cancellationToken = default);
+    Task<Resource?> PatchAsync(Uri uri, object body, CancellationToken cancellationToken = default);
+    Task<Resource?> PatchAsync(Uri uri, HttpContent content, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Uri uri, CancellationToken cancellationToken = default);
+}
+```
+
+---
+
+### `HalClient`
+
+Sealed implementation of `IHalClient`. Wraps an `HttpClient` and applies HAL-specific request/response behavior.
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public sealed class HalClient : IHalClient
+{
+    public HalClient(HttpClient httpClient, HalClientOptions options);
+    public HalClient(HttpClient httpClient, IOptions<HalClientOptions> options);
+}
+```
+
+**Fields stored:**
+- `_httpClient` -- the underlying `HttpClient`
+- `_options` -- resolved `HalClientOptions` (unwrapped from `IOptions<T>` if applicable)
+
+**Constructor behavior:**
+- The `IOptions<HalClientOptions>` constructor unwraps `options.Value` and delegates to the primary constructor.
+
+---
+
+### `HalLinkNotFoundException`
+
+Thrown before any HTTP request when a requested rel is not found on the resource.
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public sealed class HalLinkNotFoundException : Exception
+{
+    public string Rel { get; }
+    public string? SelfHref { get; }
+
+    public HalLinkNotFoundException(string rel, string? selfHref);
+}
+```
+
+**Message format:** `"Link relation '{rel}' not found on resource '{selfHref}'."`
+
+---
+
+### `HalResponseException`
+
+Thrown when `StrictContentType` is `true` and the response `Content-Type` does not indicate a HAL media type.
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public sealed class HalResponseException : Exception
+{
+    public Uri RequestUri { get; }
+    public string? ContentType { get; }
+
+    public HalResponseException(Uri requestUri, string? contentType);
+}
+```
+
+**Message format:** `"Response from '{requestUri}' has Content-Type '{contentType}', expected HAL media type."`
+
+---
+
+## HalClient Request/Response Flow
+
+All HTTP methods in `HalClient` follow the same core flow. The verb-specific behavior is noted where it differs.
+
+```
+SendAsync(HttpMethod method, Uri uri, HttpContent? content, CancellationToken ct):
+    // 1. Build request
+    request = new HttpRequestMessage(method, uri)
+    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(_options.MediaType))
+    if content is not null:
+        request.Content = content
+
+    // 2. Send request
+    response = await _httpClient.SendAsync(request, ct)
+
+    // 3. Handle 404
+    if response.StatusCode == HttpStatusCode.NotFound:
+        return null
+
+    // 4. Ensure success (throws HttpRequestException for 5xx, etc.)
+    response.EnsureSuccessStatusCode()
+
+    // 5. Validate Content-Type
+    responseContentType = response.Content.Headers.ContentType?.MediaType
+    if responseContentType is not a HAL media type:
+        if _options.StrictContentType:
+            throw new HalResponseException(uri, responseContentType)
+        return null
+
+    // 6. Deserialize
+    json = await response.Content.ReadAsStringAsync(ct)
+    jsonOptions = _options.JsonOptions ?? defaultHalJsonOptions
+    return JsonSerializer.Deserialize<Resource>(json, jsonOptions)
+```
+
+**Verb-specific behavior:**
+
+- **`GetAsync`:** `method = HttpMethod.Get`, no content.
+- **`GetAsync<T>`:** Same as `GetAsync` but deserializes as `Resource<T>`.
+- **`PostAsync(object body)`:** `method = HttpMethod.Post`, body serialized to `StringContent` with `application/json` media type.
+- **`PostAsync(HttpContent)`:** `method = HttpMethod.Post`, raw content passed through.
+- **`PutAsync`:** Same pattern as `PostAsync` with `HttpMethod.Put`.
+- **`PatchAsync`:** Same pattern as `PostAsync` with `HttpMethod.Patch`.
+- **`DeleteAsync`:** `method = HttpMethod.Delete`, no content, no response deserialization. Calls `EnsureSuccessStatusCode()` and returns. Returns normally on 404.
+
+**Object body serialization:** When a method accepts `object body`, the body is serialized via `JsonSerializer.Serialize(body, _options.JsonOptions ?? defaultHalJsonOptions)` and wrapped in `StringContent` with media type `"application/json"` and `UTF-8` encoding.
+
+---
+
+## DI Registration
+
+### `HalClientServiceCollectionExtensions`
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public static class HalClientServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers IHalClient/HalClient with an internally managed HttpClient.
+    /// </summary>
+    public static IServiceCollection AddHalClient(
+        this IServiceCollection services,
+        Action<HalClientOptions> configure);
+}
+```
+
+**Registration sequence:**
+1. Configure `HalClientOptions` via `services.Configure(configure)`
+2. Register `HttpClient` as a typed client for `HalClient`
+3. Register `IHalClient` -> `HalClient` (transient, resolved via DI)
+4. Return `services` for chaining
+
+### `HalClientHttpClientBuilderExtensions`
+
+```csharp
+namespace Chatter.Rest.Hal.Client;
+
+public static class HalClientHttpClientBuilderExtensions
+{
+    /// <summary>
+    /// Composes HalClientOptions with an IHttpClientFactory-managed typed client.
+    /// </summary>
+    public static IHttpClientBuilder AddHalOptions(
+        this IHttpClientBuilder builder,
+        Action<HalClientOptions> configure);
+}
+```
+
+**Registration sequence:**
+1. Configure `HalClientOptions` via `builder.Services.Configure(configure)`
+2. Register `IHalClient` -> `HalClient` (uses the typed `HttpClient` from the builder)
+3. Return `builder` for chaining
+
+---
+
+## Link Traversal -- Extension Methods on `Resource`
+
+All extension methods live in `Chatter.Rest.Hal.Client.Extensions`.
+
+### Link resolution (shared logic)
+
+```
+ResolveLink(Resource resource, string rel):
+    link = resource.Links?.FirstOrDefault(l => l.Rel == rel)
+    if link is null or link.LinkObjects is empty:
+        selfHref = resource.Links?
+            .FirstOrDefault(l => l.Rel == "self")?
+            .LinkObjects?.FirstOrDefault()?.Href
+        throw new HalLinkNotFoundException(rel, selfHref)
+    return link
+```
+
+This resolution is used by all `FollowLink`, `FollowLinks`, `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` methods. The `HalLinkNotFoundException` is thrown before any HTTP request (REQ-32).
+
+---
+
+### `FollowLink` -- single link, GET
+
+```csharp
+// Non-templated, untyped
+public static Task<Resource?> FollowLink(
+    this Resource resource,
+    string rel,
+    IHalClient client,
+    CancellationToken ct = default);
+
+// Non-templated, typed
+public static Task<Resource<T>?> FollowLink<T>(
+    this Resource resource,
+    string rel,
+    IHalClient client,
+    CancellationToken ct = default);
+
+// Templated, untyped
+public static Task<Resource?> FollowLink(
+    this Resource resource,
+    string rel,
+    IHalClient client,
+    object variables,
+    CancellationToken ct = default);
+
+// Templated, typed
+public static Task<Resource<T>?> FollowLink<T>(
+    this Resource resource,
+    string rel,
+    IHalClient client,
+    object variables,
+    CancellationToken ct = default);
+```
+
+**Non-templated flow:**
+1. Call `ResolveLink(resource, rel)` to get the `Link`
+2. Extract `linkObject = link.LinkObjects[0]`
+3. Construct `Uri` from `linkObject.Href`
+4. Call `client.GetAsync(uri, ct)` or `client.GetAsync<T>(uri, ct)`
+
+**Templated flow:**
+1. Call `ResolveLink(resource, rel)` to get the `Link`
+2. Extract `linkObject = link.LinkObjects[0]`
+3. Call `linkObject.Expand(variables)` to resolve the templated href (delegates to `Chatter.Rest.UriTemplates`)
+4. Construct `Uri` from the expanded href
+5. Call `client.GetAsync(uri, ct)` or `client.GetAsync<T>(uri, ct)`
+
+---
+
+### `FollowLinks` -- array-valued rel, GET
+
+```csharp
+public static IAsyncEnumerable<Resource?> FollowLinks(
+    this Resource resource,
+    string rel,
+    IHalClient client,
+    CancellationToken ct = default);
+```
+
+**Flow:**
+1. Call `ResolveLink(resource, rel)` to get the `Link`
+2. For each `linkObject` in `link.LinkObjects`:
+   a. Construct `Uri` from `linkObject.Href`
+   b. `yield return await client.GetAsync(uri, ct)`
+
+Each link is fetched sequentially. The caller controls iteration via `await foreach`.
+
+---
+
+### `PostTo`, `PutTo`, `PatchTo` -- mutation
+
+Three overloads per verb:
+
+```csharp
+// Typed body + typed response
+public static Task<Resource<TResponse>?> PostTo<TBody, TResponse>(
+    this Resource resource,
+    string rel,
+    TBody body,
+    IHalClient client,
+    CancellationToken ct = default);
+
+// Object body
+public static Task<Resource?> PostTo(
+    this Resource resource,
+    string rel,
+    object body,
+    IHalClient client,
+    CancellationToken ct = default);
+
+// Raw HttpContent
+public static Task<Resource?> PostTo(
+    this Resource resource,
+    string rel,
+    HttpContent content,
+    IHalClient client,
+    CancellationToken ct = default);
+```
+
+`PutTo` and `PatchTo` follow the same three-overload pattern, calling `client.PutAsync` and `client.PatchAsync` respectively.
+
+**Flow (all mutation methods):**
+1. Call `ResolveLink(resource, rel)` to get the `Link`
+2. Extract `linkObject = link.LinkObjects[0]`
+3. Construct `Uri` from `linkObject.Href`
+4. Call the appropriate `client.PostAsync` / `client.PutAsync` / `client.PatchAsync` overload
+
+---
+
+### `DeleteTo` -- deletion
+
+```csharp
+public static Task DeleteTo(
+    this Resource resource,
+    string rel,
+    IHalClient client,
+    CancellationToken ct = default);
+```
+
+**Flow:**
+1. Call `ResolveLink(resource, rel)` to get the `Link`
+2. Extract `linkObject = link.LinkObjects[0]`
+3. Construct `Uri` from `linkObject.Href`
+4. Call `client.DeleteAsync(uri, ct)`
+
+Returns `Task`, not `Task<Resource?>`. No response body is deserialized.
+
+---
+
+### Raw `HttpClient` overloads
+
+Every `FollowLink`, `FollowLinks`, `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` method has a corresponding overload that accepts `HttpClient` in place of `IHalClient`. These overloads construct a `HalClient` with default `HalClientOptions` and delegate to the `IHalClient` overload.
+
+```csharp
+// Example: raw HttpClient overload for FollowLink
+public static Task<Resource?> FollowLink(
+    this Resource resource,
+    string rel,
+    HttpClient client,
+    CancellationToken ct = default)
+{
+    var halClient = new HalClient(client, new HalClientOptions());
+    return resource.FollowLink(rel, halClient, ct);
+}
+```
+
+---
+
+## HttpClient Convenience Extensions
+
+Top-level fetch methods that do not require constructing a `HalClient` or having an existing `Resource`.
+
+```csharp
+namespace Chatter.Rest.Hal.Client.Extensions;
+
+public static class HttpClientHalExtensions
+{
+    public static Task<Resource?> GetHalAsync(
+        this HttpClient client,
+        Uri uri,
+        HalClientOptions? options = null,
+        CancellationToken ct = default);
+
+    public static Task<Resource<T>?> GetHalAsync<T>(
+        this HttpClient client,
+        Uri uri,
+        HalClientOptions? options = null,
+        CancellationToken ct = default);
+
+    public static Task<Resource?> PostHalAsync(
+        this HttpClient client,
+        Uri uri,
+        object body,
+        HalClientOptions? options = null,
+        CancellationToken ct = default);
+
+    public static Task<Resource?> PostHalAsync(
+        this HttpClient client,
+        Uri uri,
+        HttpContent content,
+        HalClientOptions? options = null,
+        CancellationToken ct = default);
+}
+```
+
+**Flow:** Each method creates a `HalClient(client, options ?? new HalClientOptions())` and delegates to the corresponding `IHalClient` method.
+
+---
+
+## Error Handling Summary
+
+| Condition | Behavior | Error type |
+|---|---|---|
+| Rel not found on resource | Throw before HTTP | `HalLinkNotFoundException` |
+| HTTP 404 | Return `null` | -- |
+| HTTP 5xx | Throw | `HttpRequestException` (from `HttpClient`) |
+| Network / timeout | Throw | `HttpRequestException` / `TaskCanceledException` (from `HttpClient`) |
+| Non-HAL Content-Type, strict off | Return `null` | -- |
+| Non-HAL Content-Type, strict on | Throw | `HalResponseException` |
+
+---
+
+## Serialization
+
+**Request serialization:** Object bodies are serialized via `JsonSerializer.Serialize(body, jsonOptions)` where `jsonOptions` is `HalClientOptions.JsonOptions` or library defaults. The resulting JSON is wrapped in `StringContent` with `Content-Type: application/json; charset=utf-8`.
+
+**Response deserialization:** Response bodies are deserialized via `JsonSerializer.Deserialize<Resource>(json, jsonOptions)` or `JsonSerializer.Deserialize<Resource<T>>(json, jsonOptions)` with HAL converters applied. The `jsonOptions` are `HalClientOptions.JsonOptions` or library defaults (which include `AddHalConverters()`).
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+**`HalClient` request behavior:**
+- Sets `Accept` header to `HalClientOptions.MediaType` on all requests
+- Sends correct HTTP method for each verb
+- Serializes object body as JSON `StringContent`
+- Passes raw `HttpContent` through unchanged
+- Includes `CancellationToken` in all HTTP calls
+
+**`HalClient` response handling:**
+- Returns `null` on HTTP 404
+- Throws `HttpRequestException` on 5xx
+- Returns deserialized `Resource` on success with HAL Content-Type
+- Returns deserialized `Resource<T>` on typed GET success
+- Returns `null` on non-HAL Content-Type when `StrictContentType = false`
+- Throws `HalResponseException` on non-HAL Content-Type when `StrictContentType = true`
+- `DeleteAsync` returns normally on 404
+- `DeleteAsync` does not attempt response deserialization
+- Uses custom `JsonOptions` when provided
+
+**`HalLinkNotFoundException`:**
+- Carries correct `Rel` and `SelfHref` properties
+- Message format matches spec
+
+**`HalResponseException`:**
+- Carries correct `RequestUri` and `ContentType` properties
+- Message format matches spec
+
+### Extension method tests
+
+**`FollowLink`:**
+- Resolves non-templated link and calls `GetAsync`
+- Resolves templated link via `LinkObject.Expand()` and calls `GetAsync`
+- Throws `HalLinkNotFoundException` when rel is absent
+- Returns typed `Resource<T>` for generic overload
+- Raw `HttpClient` overload delegates correctly
+
+**`FollowLinks`:**
+- Iterates all `LinkObject` entries for array-valued rel
+- Yields each fetched `Resource?` via `IAsyncEnumerable`
+- Throws `HalLinkNotFoundException` when rel is absent
+
+**`PostTo` / `PutTo` / `PatchTo`:**
+- Resolves link and calls correct HTTP method
+- Typed overload returns `Resource<TResponse>`
+- Object body overload serializes and sends
+- `HttpContent` overload passes through
+- Throws `HalLinkNotFoundException` when rel is absent
+
+**`DeleteTo`:**
+- Resolves link and calls `DeleteAsync`
+- Returns `Task` (no body)
+- Throws `HalLinkNotFoundException` when rel is absent
+
+**`GetHalAsync` / `PostHalAsync` (HttpClient extensions):**
+- Constructs `HalClient` with provided or default options
+- Delegates to correct `IHalClient` method
+
+### Integration tests
+
+**DI registration -- `AddHalClient`:**
+- Resolves `IHalClient` from container
+- Applies configured `HalClientOptions`
+- `HttpClient` is managed internally
+
+**DI registration -- `AddHalOptions` with `IHttpClientFactory`:**
+- Resolves `IHalClient` from container
+- `HttpClient` lifecycle managed by factory
+- Options are applied correctly
+
+**End-to-end traversal:**
+- Mock `HttpClient` (via `HttpMessageHandler`) returning HAL JSON
+- GET root -> `FollowLink` to sub-resource -> `PostTo` to create -> `DeleteTo` to remove
+- Verify correct URIs, methods, headers, and deserialized responses at each step

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -1,0 +1,272 @@
+# Chatter.Rest.Hal.Client -- Requirements
+
+This document is the source of truth for what the `Chatter.Rest.Hal.Client` package does. Test scenarios are derived directly from the numbered requirements below. For how the system is built, see [architecture.md](architecture.md).
+
+---
+
+## Overview
+
+`Chatter.Rest.Hal.Client` is a new NuGet package that provides an HTTP client for consuming HAL (Hypertext Application Language) APIs. It wraps `HttpClient` with HAL-aware request/response handling, typed deserialization into the existing `Resource` / `Resource<T>` domain model, and fluent link-traversal extension methods that let callers navigate a HAL API by following rels -- without writing HTTP boilerplate or RFC 6570 expansion code.
+
+### Package dependencies
+
+- `Chatter.Rest.Hal` -- core HAL types (`Resource`, `Resource<T>`, `LinkObject`, `LinkCollection`, `Link`)
+- `Chatter.Rest.UriTemplates` -- RFC 6570 URI template expansion (used for templated link traversal)
+- `System.Net.Http` -- no new transitive dependencies beyond this
+
+---
+
+## Personas
+
+### API consumer
+
+Building a .NET client against a third-party or internal HAL API. Wants to navigate links and follow rels without writing HTTP boilerplate or RFC 6570 expansion code.
+
+### Application developer
+
+Building an app that calls a HAL API. Wants DI-friendly registration, typed deserialization, and clean error semantics -- not raw `HttpClient` management.
+
+### Library consumer
+
+Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to add client navigation to the same app with a familiar API surface.
+
+---
+
+## Functional Requirements
+
+### Core client
+
+**REQ-01:** `HalClient` implements `IHalClient` and wraps an `HttpClient` with HAL-specific request/response behavior. It accepts `HalClientOptions` directly or via `IOptions<HalClientOptions>` for DI integration.
+
+**REQ-02:** `IHalClient` exposes async methods for all standard HTTP verbs: `GetAsync`, `PostAsync`, `PutAsync`, `PatchAsync`, and `DeleteAsync`. All methods accept a `Uri` parameter and a `CancellationToken` with a default value.
+
+**REQ-03:** `GetAsync` returns `Resource?` (untyped) or `Resource<T>?` (typed). Both overloads return `null` when the server responds with HTTP 404.
+
+**REQ-04:** `PostAsync`, `PutAsync`, and `PatchAsync` each have two overloads: one accepting an `object` body (serialized as JSON) and one accepting raw `HttpContent`. Both return `Resource?`.
+
+**REQ-05:** `DeleteAsync` returns `Task` (no body). It does not attempt to deserialize the response.
+
+### Request behavior
+
+**REQ-06:** All HTTP requests sent by `HalClient` include the `Accept` header set to the value of `HalClientOptions.MediaType`. The default media type is `"application/hal+json"`.
+
+**REQ-07:** All async methods on `IHalClient` accept a `CancellationToken` parameter with a default value of `default`, enabling cooperative cancellation throughout the call chain.
+
+### Response handling and error contract
+
+**REQ-08:** When the server returns HTTP 404, `GetAsync`, `PostAsync`, `PutAsync`, `PatchAsync` return `null`. `DeleteAsync` completes normally.
+
+**REQ-09:** When the server returns HTTP 5xx, the underlying `HttpClient` throws `HttpRequestException`. `HalClient` does not catch or wrap this exception.
+
+**REQ-10:** Network errors and timeouts propagate naturally from `HttpClient`. `HalClient` does not add retry or timeout logic.
+
+**REQ-11:** When the response `Content-Type` is not a HAL media type and `HalClientOptions.StrictContentType` is `false` (the default), the method returns `null`.
+
+**REQ-12:** When the response `Content-Type` is not a HAL media type and `HalClientOptions.StrictContentType` is `true`, the method throws `HalResponseException`.
+
+### Configuration
+
+**REQ-13:** `HalClientOptions.MediaType` controls the `Accept` header value. Default: `"application/hal+json"`.
+
+**REQ-14:** `HalClientOptions.StrictContentType` controls non-HAL response behavior. Default: `false` (return `null`). When `true`, throws `HalResponseException`.
+
+**REQ-15:** `HalClientOptions.JsonOptions` provides custom `JsonSerializerOptions` for deserialization. When `null`, library defaults are used.
+
+### DI registration
+
+**REQ-16:** `AddHalClient(Action<HalClientOptions>)` is an extension method on `IServiceCollection` that registers `IHalClient` / `HalClient` as a service and manages the `HttpClient` internally.
+
+**REQ-17:** `AddHalOptions(Action<HalClientOptions>)` is an extension method on `IHttpClientBuilder` that composes `HalClient` with `IHttpClientFactory`, enabling Polly policies, auth `DelegatingHandler`s, and named/typed client lifecycle management.
+
+**REQ-18:** Both registration paths resolve `IHalClient` to `HalClient` in the DI container.
+
+### Link traversal -- extension methods on `Resource`
+
+**REQ-19:** `FollowLink(string rel, IHalClient client)` resolves a single non-templated link on the resource and performs an HTTP GET via the provided `IHalClient`. Returns `Resource?`. Throws `HalLinkNotFoundException` before any HTTP call if the rel is not present on the resource.
+
+**REQ-20:** `FollowLink<T>(string rel, IHalClient client)` performs the same resolution as REQ-19 but deserializes the response as `Resource<T>?`.
+
+**REQ-21:** `FollowLink(string rel, IHalClient client, object variables)` resolves a templated link by delegating to `LinkObject.Expand()` with the provided variables, then performs an HTTP GET. Returns `Resource?`. Throws `HalLinkNotFoundException` if the rel is absent.
+
+**REQ-22:** `FollowLink<T>(string rel, IHalClient client, object variables)` performs the same templated resolution as REQ-21 but deserializes the response as `Resource<T>?`.
+
+**REQ-23:** `FollowLinks(string rel, IHalClient client)` iterates all `LinkObject` entries for an array-valued rel, performs an HTTP GET for each, and yields results as `IAsyncEnumerable<Resource?>`. Throws `HalLinkNotFoundException` if the rel is absent.
+
+**REQ-24:** Raw `HttpClient` overloads exist for every `FollowLink` and `FollowLinks` signature. These use default `HalClientOptions` and accept `HttpClient` in place of `IHalClient`.
+
+### Mutation -- extension methods on `Resource`
+
+**REQ-25:** `PostTo` has three overloads: (a) `PostTo<TBody, TResponse>(string rel, TBody body, IHalClient client)` returning `Resource<TResponse>?`, (b) `PostTo(string rel, object body, IHalClient client)` returning `Resource?`, and (c) `PostTo(string rel, HttpContent content, IHalClient client)` returning `Resource?`. All throw `HalLinkNotFoundException` if the rel is absent.
+
+**REQ-26:** `PutTo` has the same three overloads as `PostTo` (REQ-25), using HTTP PUT.
+
+**REQ-27:** `PatchTo` has the same three overloads as `PostTo` (REQ-25), using HTTP PATCH.
+
+**REQ-28:** `DeleteTo(string rel, IHalClient client)` has a single overload with no body. It returns `Task` (not `Task<Resource?>`). Throws `HalLinkNotFoundException` if the rel is absent.
+
+**REQ-29:** Raw `HttpClient` overloads exist for every `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` signature.
+
+### HttpClient convenience extensions
+
+**REQ-30:** `GetHalAsync(this HttpClient, Uri, HalClientOptions?, CancellationToken)` and `GetHalAsync<T>(this HttpClient, Uri, HalClientOptions?, CancellationToken)` provide top-level HAL fetch without constructing a `HalClient`.
+
+**REQ-31:** `PostHalAsync(this HttpClient, Uri, object body, HalClientOptions?, CancellationToken)` and `PostHalAsync(this HttpClient, Uri, HttpContent content, HalClientOptions?, CancellationToken)` provide top-level HAL POST without constructing a `HalClient`.
+
+### Error types
+
+**REQ-32:** `HalLinkNotFoundException` is thrown before any HTTP request when a requested rel is not found on the resource. It carries the rel name and the resource's self href.
+
+**REQ-33:** `HalResponseException` is thrown when `StrictContentType` is `true` and the response `Content-Type` is not a HAL media type.
+
+### Testability
+
+**REQ-34:** `IHalClient` is the primary abstraction for all client operations. Callers depend on the interface, enabling mock/stub injection in tests without requiring a live HTTP server.
+
+---
+
+## Error Handling Summary
+
+| Scenario | Behavior |
+|---|---|
+| Rel not found on resource | Throw `HalLinkNotFoundException` (before any HTTP) |
+| HTTP 404 | Return `null` |
+| HTTP 5xx | Throw `HttpRequestException` (from `HttpClient`) |
+| Network / timeout | `HttpClient` throws naturally |
+| Non-HAL Content-Type, `StrictContentType = false` | Return `null` |
+| Non-HAL Content-Type, `StrictContentType = true` | Throw `HalResponseException` |
+
+---
+
+## Integration Story
+
+The following shows two ways to register `HalClient` in a .NET application:
+
+### Option A -- simple registration
+
+```csharp
+// Manages HttpClient internally
+services.AddHalClient(options =>
+{
+    options.MediaType = "application/hal+json";
+    options.StrictContentType = true;
+});
+```
+
+### Option B -- compose with IHttpClientFactory
+
+```csharp
+// Full IHttpClientFactory lifecycle: Polly, DelegatingHandlers, named clients
+services.AddHttpClient<HalClient>(c =>
+        c.BaseAddress = new Uri("https://api.example.com"))
+    .AddHalOptions(options =>
+    {
+        options.StrictContentType = true;
+    });
+```
+
+Both register `IHalClient` -> `HalClient` in DI. Option B uses `IHttpClientFactory` lifecycle.
+
+---
+
+## Behavioral Scenarios
+
+These scenarios describe end-to-end behavior for test derivation.
+
+### Scenario: Follow a single link
+
+1. Caller has a `Resource` with `_links: { self: { href: "/orders" }, item: { href: "/orders/42" } }`
+2. Caller calls `resource.FollowLink("item", halClient)`
+3. `HalClient` sends `GET /orders/42` with `Accept: application/hal+json`
+4. Server responds with `200 OK` and a HAL resource
+5. Method returns `Resource` deserialized from the response
+
+### Scenario: Follow a typed link
+
+1. Caller has a `Resource` with `_links: { details: { href: "/orders/42/details" } }`
+2. Caller calls `resource.FollowLink<OrderDetails>("details", halClient)`
+3. `HalClient` sends `GET /orders/42/details` with `Accept: application/hal+json`
+4. Server responds with `200 OK` and a HAL resource with state
+5. Method returns `Resource<OrderDetails>` with deserialized state
+
+### Scenario: Follow a templated link
+
+1. Caller has a `Resource` with `_links: { find: { href: "/orders/{id}", templated: true } }`
+2. Caller calls `resource.FollowLink("find", halClient, new { id = "42" })`
+3. `LinkObject.Expand()` resolves href to `/orders/42`
+4. `HalClient` sends `GET /orders/42`
+5. Method returns the deserialized `Resource`
+
+### Scenario: Follow array-valued links
+
+1. Caller has a `Resource` with `_links: { item: [{ href: "/orders/1" }, { href: "/orders/2" }, { href: "/orders/3" }] }`
+2. Caller calls `resource.FollowLinks("item", halClient)`
+3. Method sends `GET /orders/1`, `GET /orders/2`, `GET /orders/3` sequentially
+4. Yields each `Resource?` via `IAsyncEnumerable`
+
+### Scenario: Post to a linked resource
+
+1. Caller has a `Resource` with `_links: { create: { href: "/orders" } }`
+2. Caller calls `resource.PostTo("create", new { product = "Widget" }, halClient)`
+3. `HalClient` sends `POST /orders` with JSON body and `Accept: application/hal+json`
+4. Server responds with `201 Created` and a HAL resource
+5. Method returns the deserialized `Resource`
+
+### Scenario: Delete a linked resource
+
+1. Caller has a `Resource` with `_links: { cancel: { href: "/orders/42/cancel" } }`
+2. Caller calls `resource.DeleteTo("cancel", halClient)`
+3. `HalClient` sends `DELETE /orders/42/cancel`
+4. Method returns `Task` (no body deserialization)
+
+### Scenario: Rel not found
+
+1. Caller has a `Resource` with `_links: { self: { href: "/orders" } }`
+2. Caller calls `resource.FollowLink("nonexistent", halClient)`
+3. Method throws `HalLinkNotFoundException` with rel `"nonexistent"` and self href `"/orders"`
+4. No HTTP request is made
+
+### Scenario: HTTP 404 response
+
+1. Caller calls `resource.FollowLink("item", halClient)`
+2. `HalClient` sends `GET /orders/42`
+3. Server responds with `404 Not Found`
+4. Method returns `null`
+
+### Scenario: Non-HAL response with strict mode
+
+1. `HalClientOptions.StrictContentType = true`
+2. Caller calls `resource.FollowLink("health", halClient)`
+3. `HalClient` sends `GET /health`
+4. Server responds with `200 OK` and `Content-Type: text/plain`
+5. Method throws `HalResponseException`
+
+### Scenario: Non-HAL response with lenient mode
+
+1. `HalClientOptions.StrictContentType = false` (default)
+2. Caller calls `resource.FollowLink("health", halClient)`
+3. `HalClient` sends `GET /health`
+4. Server responds with `200 OK` and `Content-Type: text/plain`
+5. Method returns `null`
+
+### Scenario: Convenience extension on raw HttpClient
+
+1. Caller has an `HttpClient` but no `HalClient`
+2. Caller calls `httpClient.GetHalAsync(new Uri("/orders"))`
+3. Extension sends `GET /orders` with `Accept: application/hal+json`
+4. Server responds with `200 OK` and a HAL resource
+5. Method returns the deserialized `Resource`
+
+---
+
+## Out of Scope (v1)
+
+The following capabilities are explicitly deferred and must not be implemented in the initial version:
+
+- **Automatic pagination** -- `FollowLinks` does not chase `next` links; it iterates a single array-valued rel
+- **Retry / resilience** -- no built-in retry; users compose Polly via `IHttpClientFactory`
+- **Caching** -- no HTTP cache or ETag handling
+- **HAL-FORMS support** -- form-based actions are not interpreted
+- **CURIE expansion** -- CURIE rels are not expanded; callers use compact form
+- **Batch requests** -- no multi-resource fetch optimization
+- **Streaming / SSE** -- no server-sent events or streaming response support
+- **Authentication** -- no built-in auth; users configure `DelegatingHandler`s via `IHttpClientFactory`


### PR DESCRIPTION
## Summary

- Adds `docs/client/requirements.md` — 34 numbered requirements covering GET traversal, mutation verbs, error contract, DI registration, cancellation, and testability
- Adds `docs/client/architecture.md` — full type signatures for `IHalClient`, `HalClient`, `HalClientOptions`, `HalLinkNotFoundException`, `HalResponseException`, DI extension methods, and all `Resource` extension methods

## Design decisions captured

- `FollowLink` = GET always; `LinkObject` stays spec-pure (no `method` property)
- Error split: rel-not-found throws `HalLinkNotFoundException` (programming error); HTTP 404 returns `null`; 5xx throws `HttpRequestException`; non-HAL response returns `null` or throws if `StrictContentType = true`
- Mutation API: `PostTo`/`PutTo`/`PatchTo`/`DeleteTo` with three body-type overloads each (typed `T`, `object`, `HttpContent`)
- DI: both simple `AddHalClient()` and `IHttpClientFactory`-composable `AddHalOptions()` paths
- `IHalClient` interface for testability
- `FollowLinks` (plural) returns `IAsyncEnumerable<Resource?>` for array-valued rels
- `CancellationToken` on all async methods

## Test plan

- [ ] Verify docs render correctly in GitHub
- [ ] Confirm all design decisions from brainstorm session are captured
- [ ] Confirm IDEA-02 (MCP) prerequisites reference IDEA-04 correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)