### PR TITLE
docs: add logging requirements and architecture for Client and MCP packages

### DIFF
--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -471,6 +471,59 @@ public static class HttpClientHalExtensions
 
 ---
 
+## Logging Architecture
+
+### ILogger<T> Injection
+
+`HalClient` accepts `ILogger<HalClient>` as a constructor parameter (REQ-35). The `IHalClient` interface is not modified — logging is a `HalClient` implementation detail.
+
+```csharp
+public sealed class HalClient : IHalClient
+{
+    public HalClient(HttpClient httpClient, HalClientOptions options, ILogger<HalClient>? logger = null);
+    public HalClient(HttpClient httpClient, IOptions<HalClientOptions> options, ILogger<HalClient>? logger = null);
+}
+```
+
+The `ILogger<HalClient>` parameter is optional (defaulting to `null`) so that callers who do not use DI can construct `HalClient` without a logger. When `null`, a `NullLogger<HalClient>` is used internally.
+
+**Extension method logging:** `FollowLink`, `FollowLinks`, `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` extension methods accept an optional `ILogger? logger = null` parameter for rel-resolution logging (REQ-41, REQ-42). Callers that want debug-level rel-resolution logging pass their own logger explicitly. This avoids adding a logging accessor to `IHalClient` (a breaking interface change) and avoids service-locator patterns.
+
+**Rejected alternative:** Adding an internal `ILogger` property to `HalClient` accessible via a cast from `IHalClient`. Rejected because it couples extension methods to the concrete type, breaks the `IHalClient` abstraction, and cannot work when callers substitute a mock `IHalClient`.
+
+---
+
+### LoggerMessage Source Generators
+
+All log points are defined as `[LoggerMessage]` attributed static partial methods (REQ-44). These are declared as a partial class on `HalClient` or in a companion file `HalClientLog.cs`.
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogSendingRequest` | Debug | 1 | `"Sending {Method} {Uri}"` | `Method`, `Uri` |
+| `LogReceivedResponse` | Debug | 2 | `"Received {StatusCode} from {Method} {Uri}"` | `StatusCode`, `Method`, `Uri` |
+| `LogNotFoundReturningNull` | Debug | 3 | `"Received 404 for {Method} {Uri}, returning null"` | `Method`, `Uri` |
+| `LogNonHalContentType` | Warning | 4 | `"Response from {Uri} has Content-Type '{ContentType}', expected HAL media type; returning null"` | `Uri`, `ContentType` |
+| `LogDeserializationFailed` | Error | 5 | `"Failed to deserialize HAL response from {Uri}"` | `Uri` (exception passed as `Exception` arg) |
+| `LogResolvingLink` | Debug | 6 | `"Resolving rel '{Rel}' on resource '{SelfHref}': href={Href}, templated={Templated}"` | `Rel`, `SelfHref`, `Href`, `Templated` |
+| `LogMutationRequest` | Debug | 7 | `"Sending {Method} to rel '{Rel}', uri={Uri}"` | `Method`, `Rel`, `Uri` |
+| `LogHalClientInitialized` | Debug | 8 | `"HalClient initialized"` | (none) |
+
+Event IDs are scoped to the `HalClient` category. `LogHalClientInitialized` is emitted once per `HalClient` instance construction (REQ-43).
+
+---
+
+### IsEnabled Guards
+
+`LoggerMessage` source generators handle the `IsEnabled` check internally for fixed log points. Explicit `IsEnabled` guards are only needed when building expensive log state (e.g., constructing a string from iteration) before the log call. `HalClient` has no such iterating log points; all log messages use fixed structured parameters.
+
+---
+
+### Sensitive Data
+
+Auth headers, request bodies, and response bodies must never appear in log messages (REQ-45). The log point table above lists only safe parameters: HTTP method, URI, status code, rel name, and content type.
+
+---
+
 ## Test Strategy
 
 ### Unit tests
@@ -547,3 +600,12 @@ public static class HttpClientHalExtensions
 - Mock `HttpClient` (via `HttpMessageHandler`) returning HAL JSON
 - GET root -> `FollowLink` to sub-resource -> `PostTo` to create -> `DeleteTo` to remove
 - Verify correct URIs, methods, headers, and deserialized responses at each step
+
+### Logging
+
+- Verify `HalClient` emits `Debug` log before and after each HTTP call when a real logger is provided
+- Verify `HalClient` emits `Warning` when non-HAL Content-Type is received in lenient mode
+- Verify `HalClient` emits `Error` on deserialization failure, including exception
+- Verify no log calls throw when `NullLogger<HalClient>` is used (covers no-logging construction path)
+- Use `Microsoft.Extensions.Logging.Testing.FakeLogger<HalClient>` or a mock `ILogger<HalClient>` to assert exact log level, event ID, and message structure
+- Verify `LogHalClientInitialized` is emitted exactly once per `HalClient` construction

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -122,6 +122,30 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 **REQ-34:** `IHalClient` is the primary abstraction for all client operations. Callers depend on the interface, enabling mock/stub injection in tests without requiring a live HTTP server.
 
+### Logging
+
+**REQ-35:** `HalClient` accepts `ILogger<HalClient>` via constructor injection. The `IHalClient` interface does not reference `ILogger`; logging is an implementation detail of `HalClient`.
+
+**REQ-36:** All log messages use structured logging with named placeholders (e.g., `{Method}`, `{Uri}`, `{StatusCode}`, `{Rel}`, `{ContentType}`) and never string concatenation or string interpolation in log calls.
+
+**REQ-37:** At `Debug` level, `HalClient` logs the HTTP method and request URI before sending each request, and the response status code after receiving the response.
+
+**REQ-38:** At `Debug` level, `HalClient` logs when a 404 response is received and `null` is returned.
+
+**REQ-39:** At `Warning` level, `HalClient` logs when the response `Content-Type` is not a HAL media type and `StrictContentType` is `false` (lenient mode: non-HAL response returned as `null`).
+
+**REQ-40:** At `Error` level, `HalClient` logs deserialization failures, including the exception and the request URI.
+
+**REQ-41:** At `Debug` level, `FollowLink` and `FollowLinks` extension methods log rel resolution: the rel name, the resolved href, and whether the link is templated. Logging occurs at the extension-method call site (not inside `HalClient`) because the extension has rel context that `HalClient` does not. Extension methods accept an optional `ILogger?` parameter (defaulting to `null`) for this purpose; callers that want rel-resolution logging pass their logger explicitly.
+
+**REQ-42:** At `Debug` level, `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` extension methods log the rel name and resolved URI before delegating to `IHalClient`. These methods follow the same optional `ILogger?` parameter pattern as `FollowLink` (REQ-41).
+
+**REQ-43:** At `Debug` level, `AddHalClient` and `AddHalOptions` log confirmation that `IHalClient` has been registered. Because these methods run during service registration before the DI container is built, the confirmation log is emitted from the `HalClient` constructor on first instantiation (one-time `Debug` message: `"HalClient initialized"`).
+
+**REQ-44:** All `Debug`-level log points in `HalClient` use `LoggerMessage` source generators to avoid string allocation when `Debug` logging is not enabled. `Trace`-level log points that iterate collections use explicit `IsEnabled(LogLevel.Trace)` guards before the loop. `Information`-level logging is limited to at most one startup message; no `Information` logging occurs on hot paths.
+
+**REQ-45:** Auth headers, request bodies, and response bodies must never appear in log messages at any log level.
+
 ---
 
 ## Error Handling Summary

--- a/docs/mcp/architecture.md
+++ b/docs/mcp/architecture.md
@@ -434,6 +434,116 @@ When returning HAL resource content in `CallToolResult`, the resource is seriali
 
 ---
 
+## Logging Architecture
+
+### ILogger<T> Injection
+
+Each stateful type accepts `ILogger<T>` via constructor injection (REQ-24). Updated constructor signatures:
+
+```csharp
+public sealed class HalMcpStartupService : IHostedService
+{
+    public HalMcpStartupService(
+        McpServerOptions mcpOptions,
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        ILogger<HalMcpStartupService> logger);
+}
+
+public sealed class HalNavigationTool : McpServerTool
+{
+    public HalNavigationTool(
+        string rel,
+        LinkObject link,
+        string selfHref,
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        McpServerOptions mcpOptions,
+        ILogger<HalNavigationTool> logger);
+}
+
+public sealed class NavigateToRootTool : McpServerTool
+{
+    public NavigateToRootTool(
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        McpServerOptions mcpOptions,
+        ILogger<NavigateToRootTool> logger);
+}
+```
+
+**`HalToolCollectionManager` (internal static):** Does not accept `ILogger`. It is a pure collection-mutation helper. All logging for tool-swap operations is performed at the call site (the tool or startup service that calls `SwapTools`), which has richer context (which tool triggered the swap, the root URI, the current navigation href). Injecting a logger into a static helper would make it impure and reduce testability without improving log quality.
+
+**`HalMcpServerBuilderExtensions.WithHalApi`:** Runs during service registration before the DI container is built, so `ILogger` is unavailable at this stage. The configured-root-uri `Debug` log is deferred to `HalMcpStartupService.StartAsync` instead. If `RootUri` validation fails, `ArgumentException` is thrown without logging — the exception message is descriptive, and the caller's exception handler is the appropriate place to log it.
+
+---
+
+### LoggerMessage Source Generators
+
+All log points are defined as `[LoggerMessage]` attributed static partial methods (REQ-35). Event IDs are scoped per category (per type).
+
+**`HalMcpStartupService` log points:**
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogConfiguredRootUri` | Debug | 1 | `"Configured RootUri: {RootUri}"` | `RootUri` |
+| `LogStartupFetchBegin` | Debug | 2 | `"Fetching root resource from {RootUri}"` | `RootUri` |
+| `LogStartupComplete` | Information | 3 | `"HAL MCP tools initialized: {ToolCount} tools registered from {RootUri}"` | `ToolCount`, `RootUri` |
+| `LogStartupFailed` | Warning | 4 | `"Failed to fetch root resource from {RootUri} on startup"` | `RootUri` (exception passed as `Exception` arg) |
+
+**`HalNavigationTool` log points:**
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogToolInvoking` | Debug | 1 | `"Invoking tool '{ToolName}', fetching {Href}"` | `ToolName`, `Href` |
+| `LogToolResponse` | Debug | 2 | `"Tool '{ToolName}' received {StatusCode} from {Href}"` | `ToolName`, `StatusCode`, `Href` |
+| `LogToolHttpError` | Warning | 3 | `"Tool '{ToolName}' received HTTP {StatusCode} from {Href}"` | `ToolName`, `StatusCode`, `Href` |
+| `LogToolNonHalResponse` | Warning | 4 | `"Tool '{ToolName}' received non-HAL response from {Href}"` | `ToolName`, `Href` |
+| `LogToolException` | Error | 5 | `"Tool '{ToolName}' failed"` | `ToolName` (exception passed as `Exception` arg) |
+| `LogToolsSwapped` | Debug | 6 | `"Tool collection updated: {RemovedCount} removed, {AddedCount} added"` | `RemovedCount`, `AddedCount` |
+| `LogToolAdded` | Trace | 7 | `"Tool added: {AddedToolName}"` | `AddedToolName` |
+
+**`NavigateToRootTool` log points:**
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogRootInvoking` | Debug | 1 | `"Navigating to root {RootUri}"` | `RootUri` |
+| `LogRootResponse` | Debug | 2 | `"Root navigation received {StatusCode} from {RootUri}"` | `StatusCode`, `RootUri` |
+| `LogRootNonHalResponse` | Warning | 3 | `"Root resource at {RootUri} was not a valid HAL resource"` | `RootUri` |
+| `LogRootException` | Error | 4 | `"Root navigation failed"` | (exception passed as `Exception` arg) |
+| `LogRootToolsSwapped` | Debug | 5 | `"Root tool collection updated: {RemovedCount} removed, {AddedCount} added"` | `RemovedCount`, `AddedCount` |
+| `LogRootToolAdded` | Trace | 6 | `"Tool added: {AddedToolName}"` | `AddedToolName` |
+
+---
+
+### SwapTools Call-Site Logging Pattern
+
+The calling tool or startup service logs before and after calling `SwapTools`. The Trace-level tool-name loop uses an explicit `IsEnabled` guard (REQ-33):
+
+```
+var previousCount = _mcpOptions.ToolCollection.Count;
+HalToolCollectionManager.SwapTools(
+    _mcpOptions.ToolCollection, response, resolvedHref,
+    _halOptions, _httpClient, _mcpOptions);
+var addedCount = _mcpOptions.ToolCollection.Count - 1; // minus navigate_to_root
+LogToolsSwapped(previousCount - 1, addedCount);
+
+if (_logger.IsEnabled(LogLevel.Trace))
+    foreach (var tool in _mcpOptions.ToolCollection)
+        if (tool.ProtocolTool.Name != "navigate_to_root")
+            LogToolAdded(tool.ProtocolTool.Name);
+```
+
+The `-1` adjusts for the persistent `navigate_to_root` tool, which is not counted in the "removed" or "added" totals.
+
+---
+
+### Sensitive Data
+
+Request bodies, response bodies, auth headers, and API keys must never appear in log messages (REQ-36). Tool names and hrefs are safe to log.
+
+---
+
 ## Test Strategy
 
 ### Unit tests
@@ -494,3 +604,13 @@ When returning HAL resource content in `CallToolResult`, the resource is seriali
 - Start at root -> navigate to sub-resource -> navigate to child -> return to root
 - Verify tool collection updates correctly at each step
 - Verify content returned at each step matches the fetched resource
+
+### Logging
+
+- Verify `HalMcpStartupService` emits `Information` with tool count on successful startup
+- Verify `HalMcpStartupService` emits `Warning` (not `Error`) when root fetch fails on startup
+- Verify `HalNavigationTool.InvokeAsync` emits `Debug` before fetch, `Warning` on HTTP error, `Warning` on non-HAL response, `Error` on exception
+- Verify `NavigateToRootTool.InvokeAsync` follows the same pattern
+- Verify Trace-level tool-name loop does not execute when Trace logging is disabled (confirms `IsEnabled` guard works)
+- Verify no log calls throw when a `NullLogger<T>` is used
+- Use `Microsoft.Extensions.Logging.Testing.FakeLogger<T>` or a mock `ILogger<T>` to assert log level, event ID, and message content

--- a/docs/mcp/requirements.md
+++ b/docs/mcp/requirements.md
@@ -127,6 +127,34 @@ Examples:
 
 **REQ-23:** `MaxDepth` traversal limiting is not implemented. The agent may traverse indefinitely.
 
+### Logging
+
+**REQ-24:** `HalMcpStartupService`, `HalNavigationTool`, and `NavigateToRootTool` each accept `ILogger<T>` via constructor injection. `HalToolCollectionManager` is an internal static helper and does not hold an `ILogger`; logging for tool-swap operations is performed at the call site (the tool or startup service that calls `SwapTools`), which has richer context about the triggering event.
+
+**REQ-25:** All log messages use structured logging with named placeholders (e.g., `{ToolName}`, `{Href}`, `{StatusCode}`, `{ToolCount}`, `{RootUri}`, `{Rel}`) and never string concatenation or string interpolation in log calls.
+
+**REQ-26:** At `Information` level, `HalMcpStartupService` logs one message on successful root fetch and tool registration, including the number of tools registered and the root URI. This is the only `Information`-level log in the package.
+
+**REQ-27:** At `Warning` level, `HalMcpStartupService` logs when the root fetch fails on startup, including the exception and the root URI. Startup does not throw (per REQ-03).
+
+**REQ-28:** At `Debug` level, `HalNavigationTool.InvokeAsync` logs the tool name and resolved href before each HTTP fetch, and the response status code after receiving the response.
+
+**REQ-29:** At `Warning` level, `HalNavigationTool.InvokeAsync` logs when the HTTP response is a non-success status code, including the status code and resolved href.
+
+**REQ-30:** At `Warning` level, `HalNavigationTool.InvokeAsync` logs when the response is not a valid HAL resource, including the resolved href.
+
+**REQ-31:** At `Error` level, `HalNavigationTool.InvokeAsync` logs unexpected exceptions during tool invocation, including the exception and the tool name.
+
+**REQ-32:** `NavigateToRootTool.InvokeAsync` follows the same logging pattern as `HalNavigationTool` (REQ-28 through REQ-31) using its own `ILogger<NavigateToRootTool>`.
+
+**REQ-33:** At `Debug` level, after `SwapTools` completes, the calling tool or startup service logs the number of tools removed and the number of tools added. At `Trace` level, each individual tool name added to the collection is logged inside an `IsEnabled(LogLevel.Trace)` guard to avoid iteration overhead when `Trace` is not enabled.
+
+**REQ-34:** At `Debug` level, `HalMcpStartupService.StartAsync` logs the configured `RootUri` before fetching. Because `WithHalApi` runs during service registration before the DI container is built, the configured-root-uri log is deferred to `HalMcpStartupService.StartAsync` rather than emitted from `WithHalApi` directly. If `RootUri` validation fails in `WithHalApi`, the `ArgumentException` is thrown without logging — the exception message is descriptive and the caller's exception handler is the correct place to log it.
+
+**REQ-35:** All `Debug`-level log points use `LoggerMessage` source generators to avoid string allocation when `Debug` logging is not enabled. All `Trace`-level log points that iterate collections use explicit `IsEnabled(LogLevel.Trace)` guards before the loop. No `Information`-level logging occurs on hot paths (only on startup).
+
+**REQ-36:** Request bodies, response bodies, auth headers, and API keys must never appear in log messages at any log level. Tool names and hrefs are safe to log.
+
 ---
 
 ## Integration Story


### PR DESCRIPTION
## Summary

- Adds `### Logging` subsection to `docs/client/requirements.md` (REQ-35–45): `ILogger<HalClient>` injection, structured logging, log levels per operation, `LoggerMessage` source generators, sensitive-data constraints
- Adds `### Logging` subsection to `docs/mcp/requirements.md` (REQ-24–36): per-type `ILogger<T>` injection (`HalMcpStartupService`, `HalNavigationTool`, `NavigateToRootTool`), call-site logging for `HalToolCollectionManager`, Trace-level tool-name loop with `IsEnabled` guard
- Adds `## Logging Architecture` section to `docs/client/architecture.md`: updated constructor signatures, `LoggerMessage` source generator table (8 log points), extension-method optional `ILogger?` pattern with rejected-alternative reasoning, test strategy additions
- Adds `## Logging Architecture` section to `docs/mcp/architecture.md`: updated constructor signatures for all 3 types, full log-point tables (16 entries across 3 types), `SwapTools` call-site pseudocode with Trace guard, deferred-RootUri-log rationale, test strategy additions

## Test plan

- [ ] Review REQ numbering continuity in both requirements docs (client: REQ-35–45, MCP: REQ-24–36)
- [ ] Verify no existing REQ entries were modified
- [ ] Confirm log-point tables in architecture docs are complete and consistent with requirements
- [ ] Verify `## Logging Architecture` sections are placed correctly (after `## Serialization`, before `## Test Strategy`) in both architecture docs
- [ ] Confirm `### Logging` test subsections were appended to both `## Test Strategy` sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)