### PR TITLE
docs: add async, cancellation, and parallelism requirements for Client and MCP

### DIFF
--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -322,11 +322,20 @@ public static IAsyncEnumerable<Resource?> FollowLinks(
 
 **Flow:**
 1. Call `ResolveLink(resource, rel)` to get the `Link`
-2. For each `linkObject` in `link.LinkObjects`:
-   a. Construct `Uri` from `linkObject.Href`
-   b. `yield return await client.GetAsync(uri, ct)`
+2. Launch all fetches concurrently:
+   ```
+   tasks = link.LinkObjects
+       .Select(lo => client.GetAsync(new Uri(lo.Href), ct))
+       .ToArray()
+   ```
+3. Await all: `results = await Task.WhenAll(tasks)`
+4. Yield results sequentially:
+   ```
+   foreach (var result in results)
+       yield return result
+   ```
 
-Each link is fetched sequentially. The caller controls iteration via `await foreach`.
+All links are fetched concurrently via `Task.WhenAll`. Results are buffered and then yielded sequentially. The caller still consumes results via `await foreach` over `IAsyncEnumerable<Resource?>`.
 
 ---
 
@@ -471,6 +480,34 @@ public static class HttpClientHalExtensions
 
 ---
 
+## Async Conventions
+
+### Async-only I/O (REQ-46)
+
+All I/O in the package is async end-to-end. No sync-over-async wrappers (`.Result`, `.GetAwaiter().GetResult()`, `.Wait()`) or blocking calls (`Thread.Sleep`) appear anywhere in the implementation. Every public method that performs I/O returns `Task`, `Task<T>`, or `IAsyncEnumerable<T>`.
+
+---
+
+### CancellationToken threading (REQ-47)
+
+Every async method -- public, internal, or private -- that performs or delegates to I/O accepts a `CancellationToken` and passes it to every downstream async call. Public API parameters default to `default`. Internal/private async methods may require the parameter (no default) to catch missing-token bugs at compile time.
+
+Specific threading points:
+- `HalClient.SendAsync` passes `ct` to `HttpClient.SendAsync`, `ReadAsStringAsync`, and `JsonSerializer.DeserializeAsync`
+- All `FollowLink` / `FollowLinks` overloads pass `ct` through to `client.GetAsync`
+- All `PostTo` / `PutTo` / `PatchTo` / `DeleteTo` overloads pass `ct` through to `client.PostAsync` / `client.PutAsync` / `client.PatchAsync` / `client.DeleteAsync`
+- `GetHalAsync` and `PostHalAsync` convenience extensions pass `ct` through to the `HalClient` methods they delegate to
+
+---
+
+### Parallel fetches (REQ-48)
+
+`FollowLinks` is the one method in the package where independent async I/O calls iterate a collection. It uses `Task.WhenAll` to execute all fetches concurrently. The results are buffered in a `Task<Resource?>[]` and then yielded one at a time via `IAsyncEnumerable<Resource?>`. This preserves the existing return type while eliminating sequential-await overhead.
+
+Single-element and empty cases require no special handling: `Task.WhenAll` on a single task has negligible overhead; `ResolveLink` throws `HalLinkNotFoundException` before `FollowLinks` reaches the fetch step when `LinkObjects` is empty.
+
+---
+
 ## Logging Architecture
 
 ### ILogger<T> Injection
@@ -567,6 +604,7 @@ Auth headers, request bodies, and response bodies must never appear in log messa
 - Iterates all `LinkObject` entries for array-valued rel
 - Yields each fetched `Resource?` via `IAsyncEnumerable`
 - Throws `HalLinkNotFoundException` when rel is absent
+- Fetches all links concurrently (not sequentially) -- verify via mock that all `GetAsync` calls are initiated before any result is awaited
 
 **`PostTo` / `PutTo` / `PatchTo`:**
 - Resolves link and calls correct HTTP method

--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -471,6 +471,59 @@ public static class HttpClientHalExtensions
 
 ---
 
+## Logging Architecture
+
+### ILogger<T> Injection
+
+`HalClient` accepts `ILogger<HalClient>` as a constructor parameter (REQ-35). The `IHalClient` interface is not modified — logging is a `HalClient` implementation detail.
+
+```csharp
+public sealed class HalClient : IHalClient
+{
+    public HalClient(HttpClient httpClient, HalClientOptions options, ILogger<HalClient>? logger = null);
+    public HalClient(HttpClient httpClient, IOptions<HalClientOptions> options, ILogger<HalClient>? logger = null);
+}
+```
+
+The `ILogger<HalClient>` parameter is optional (defaulting to `null`) so that callers who do not use DI can construct `HalClient` without a logger. When `null`, a `NullLogger<HalClient>` is used internally.
+
+**Extension method logging:** `FollowLink`, `FollowLinks`, `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` extension methods accept an optional `ILogger? logger = null` parameter for rel-resolution logging (REQ-41, REQ-42). Callers that want debug-level rel-resolution logging pass their own logger explicitly. This avoids adding a logging accessor to `IHalClient` (a breaking interface change) and avoids service-locator patterns.
+
+**Rejected alternative:** Adding an internal `ILogger` property to `HalClient` accessible via a cast from `IHalClient`. Rejected because it couples extension methods to the concrete type, breaks the `IHalClient` abstraction, and cannot work when callers substitute a mock `IHalClient`.
+
+---
+
+### LoggerMessage Source Generators
+
+All log points are defined as `[LoggerMessage]` attributed static partial methods (REQ-44). These are declared as a partial class on `HalClient` or in a companion file `HalClientLog.cs`.
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogSendingRequest` | Debug | 1 | `"Sending {Method} {Uri}"` | `Method`, `Uri` |
+| `LogReceivedResponse` | Debug | 2 | `"Received {StatusCode} from {Method} {Uri}"` | `StatusCode`, `Method`, `Uri` |
+| `LogNotFoundReturningNull` | Debug | 3 | `"Received 404 for {Method} {Uri}, returning null"` | `Method`, `Uri` |
+| `LogNonHalContentType` | Warning | 4 | `"Response from {Uri} has Content-Type '{ContentType}', expected HAL media type; returning null"` | `Uri`, `ContentType` |
+| `LogDeserializationFailed` | Error | 5 | `"Failed to deserialize HAL response from {Uri}"` | `Uri` (exception passed as `Exception` arg) |
+| `LogResolvingLink` | Debug | 6 | `"Resolving rel '{Rel}' on resource '{SelfHref}': href={Href}, templated={Templated}"` | `Rel`, `SelfHref`, `Href`, `Templated` |
+| `LogMutationRequest` | Debug | 7 | `"Sending {Method} to rel '{Rel}', uri={Uri}"` | `Method`, `Rel`, `Uri` |
+| `LogHalClientInitialized` | Debug | 8 | `"HalClient initialized"` | (none) |
+
+Event IDs are scoped to the `HalClient` category. `LogHalClientInitialized` is emitted once per `HalClient` instance construction (REQ-43).
+
+---
+
+### IsEnabled Guards
+
+`LoggerMessage` source generators handle the `IsEnabled` check internally for fixed log points. Explicit `IsEnabled` guards are only needed when building expensive log state (e.g., constructing a string from iteration) before the log call. `HalClient` has no such iterating log points; all log messages use fixed structured parameters.
+
+---
+
+### Sensitive Data
+
+Auth headers, request bodies, and response bodies must never appear in log messages (REQ-45). The log point table above lists only safe parameters: HTTP method, URI, status code, rel name, and content type.
+
+---
+
 ## Test Strategy
 
 ### Unit tests
@@ -547,3 +600,12 @@ public static class HttpClientHalExtensions
 - Mock `HttpClient` (via `HttpMessageHandler`) returning HAL JSON
 - GET root -> `FollowLink` to sub-resource -> `PostTo` to create -> `DeleteTo` to remove
 - Verify correct URIs, methods, headers, and deserialized responses at each step
+
+### Logging
+
+- Verify `HalClient` emits `Debug` log before and after each HTTP call when a real logger is provided
+- Verify `HalClient` emits `Warning` when non-HAL Content-Type is received in lenient mode
+- Verify `HalClient` emits `Error` on deserialization failure, including exception
+- Verify no log calls throw when `NullLogger<HalClient>` is used (covers no-logging construction path)
+- Use `Microsoft.Extensions.Logging.Testing.FakeLogger<HalClient>` or a mock `ILogger<HalClient>` to assert exact log level, event ID, and message structure
+- Verify `LogHalClientInitialized` is emitted exactly once per `HalClient` construction

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -146,6 +146,14 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 **REQ-45:** Auth headers, request bodies, and response bodies must never appear in log messages at any log level.
 
+### Async and Cancellation
+
+**REQ-46:** All I/O operations in `Chatter.Rest.Hal.Client` must be async end-to-end. Synchronous-over-async patterns (`.Result`, `.GetAwaiter().GetResult()`, `.Wait()`) and blocking calls (`Thread.Sleep`) are prohibited anywhere in the implementation. Every public method that performs I/O returns `Task`, `Task<T>`, or `IAsyncEnumerable<T>`.
+
+**REQ-47:** Every async method that performs or delegates to I/O must accept a `CancellationToken` parameter and pass it through to all downstream async calls (`HttpClient.SendAsync`, `ReadAsStringAsync`, `JsonSerializer.DeserializeAsync`, etc.). On the public API surface the `CancellationToken` parameter defaults to `default`. Internal/private async methods may require the parameter (no default) to enforce threading discipline at the implementation level.
+
+**REQ-48:** When an async method iterates a collection and performs an independent async I/O call for each element, the implementation must use `Task.WhenAll` (or equivalent) to execute the calls concurrently rather than awaiting each call sequentially in a loop. `FollowLinks` is the primary case: it fetches multiple `LinkObject` entries for the same rel concurrently, buffers the results, and then yields them sequentially via `IAsyncEnumerable<Resource?>`. The return type of `FollowLinks` is not changed.
+
 ---
 
 ## Error Handling Summary
@@ -224,8 +232,8 @@ These scenarios describe end-to-end behavior for test derivation.
 
 1. Caller has a `Resource` with `_links: { item: [{ href: "/orders/1" }, { href: "/orders/2" }, { href: "/orders/3" }] }`
 2. Caller calls `resource.FollowLinks("item", halClient)`
-3. Method sends `GET /orders/1`, `GET /orders/2`, `GET /orders/3` sequentially
-4. Yields each `Resource?` via `IAsyncEnumerable`
+3. Method sends `GET /orders/1`, `GET /orders/2`, `GET /orders/3` concurrently via `Task.WhenAll`
+4. Buffers all results, then yields each `Resource?` sequentially via `IAsyncEnumerable`
 
 ### Scenario: Post to a linked resource
 

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -122,6 +122,30 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 **REQ-34:** `IHalClient` is the primary abstraction for all client operations. Callers depend on the interface, enabling mock/stub injection in tests without requiring a live HTTP server.
 
+### Logging
+
+**REQ-35:** `HalClient` accepts `ILogger<HalClient>` via constructor injection. The `IHalClient` interface does not reference `ILogger`; logging is an implementation detail of `HalClient`.
+
+**REQ-36:** All log messages use structured logging with named placeholders (e.g., `{Method}`, `{Uri}`, `{StatusCode}`, `{Rel}`, `{ContentType}`) and never string concatenation or string interpolation in log calls.
+
+**REQ-37:** At `Debug` level, `HalClient` logs the HTTP method and request URI before sending each request, and the response status code after receiving the response.
+
+**REQ-38:** At `Debug` level, `HalClient` logs when a 404 response is received and `null` is returned.
+
+**REQ-39:** At `Warning` level, `HalClient` logs when the response `Content-Type` is not a HAL media type and `StrictContentType` is `false` (lenient mode: non-HAL response returned as `null`).
+
+**REQ-40:** At `Error` level, `HalClient` logs deserialization failures, including the exception and the request URI.
+
+**REQ-41:** At `Debug` level, `FollowLink` and `FollowLinks` extension methods log rel resolution: the rel name, the resolved href, and whether the link is templated. Logging occurs at the extension-method call site (not inside `HalClient`) because the extension has rel context that `HalClient` does not. Extension methods accept an optional `ILogger?` parameter (defaulting to `null`) for this purpose; callers that want rel-resolution logging pass their logger explicitly.
+
+**REQ-42:** At `Debug` level, `PostTo`, `PutTo`, `PatchTo`, and `DeleteTo` extension methods log the rel name and resolved URI before delegating to `IHalClient`. These methods follow the same optional `ILogger?` parameter pattern as `FollowLink` (REQ-41).
+
+**REQ-43:** At `Debug` level, `AddHalClient` and `AddHalOptions` log confirmation that `IHalClient` has been registered. Because these methods run during service registration before the DI container is built, the confirmation log is emitted from the `HalClient` constructor on first instantiation (one-time `Debug` message: `"HalClient initialized"`).
+
+**REQ-44:** All `Debug`-level log points in `HalClient` use `LoggerMessage` source generators to avoid string allocation when `Debug` logging is not enabled. `Trace`-level log points that iterate collections use explicit `IsEnabled(LogLevel.Trace)` guards before the loop. `Information`-level logging is limited to at most one startup message; no `Information` logging occurs on hot paths.
+
+**REQ-45:** Auth headers, request bodies, and response bodies must never appear in log messages at any log level.
+
 ---
 
 ## Error Handling Summary

--- a/docs/mcp/architecture.md
+++ b/docs/mcp/architecture.md
@@ -151,7 +151,7 @@ public sealed class NavigateToRootTool : McpServerTool
 - `InputSchema` = `{ "type": "object", "properties": {} }` (no input parameters)
 
 **`InvokeAsync`:**
-1. Fetch `halOptions.RootUri` via `httpClient.GetHalAsync(halOptions.RootUri)`
+1. Fetch `halOptions.RootUri` via `httpClient.GetHalAsync(halOptions.RootUri, cancellationToken: cancellationToken)`
 2. If response is `null`: return `CallToolResult { IsError = true }` with message `$"Response from {halOptions.RootUri} was not a valid HAL resource"`
 3. Call `HalToolCollectionManager.SwapTools(mcpOptions.ToolCollection, response, halOptions.RootUri, halOptions, httpClient, mcpOptions)`
 4. Serialize response to HAL JSON
@@ -220,7 +220,7 @@ public sealed class HalMcpStartupService : IHostedService
 ```
 
 **`StartAsync`:**
-1. Fetch `halOptions.RootUri` via `httpClient.GetHalAsync(halOptions.RootUri)`
+1. Fetch `halOptions.RootUri` via `httpClient.GetHalAsync(halOptions.RootUri, cancellationToken: cancellationToken)`
 2. If successful: call `HalToolCollectionManager.SwapTools(...)` to populate tool collection with root's links
 3. If fetch fails (any exception or null response): catch, log warning, do not throw. The `navigate_to_root` tool (already in the collection from registration) remains available for the agent to retry.
 
@@ -345,7 +345,7 @@ InvokeAsync(request, cancellationToken):
             resolvedHref = _link.Href
 
         // 3. Fetch resource
-        response = await _httpClient.GetHalAsync(resolvedHref)
+        response = await _httpClient.GetHalAsync(resolvedHref, cancellationToken: cancellationToken)
 
         // 4. Handle non-HAL response
         if response is null:
@@ -431,6 +431,31 @@ All template variables are typed as `string` in v1 (REQ-07). The `required` arra
 ## Serialization
 
 When returning HAL resource content in `CallToolResult`, the resource is serialized using `System.Text.Json.JsonSerializer.Serialize<Resource>()` with HAL converters applied (via `JsonSerializerOptions.AddHalConverters()`). This produces standard HAL JSON including `_links`, `_embedded`, and state properties.
+
+---
+
+## Async Conventions
+
+### Async-only I/O (REQ-37)
+
+All I/O in the package is async end-to-end. No sync-over-async wrappers (`.Result`, `.GetAwaiter().GetResult()`, `.Wait()`) or blocking calls (`Thread.Sleep`) appear anywhere. `HalMcpStartupService.StartAsync`, `HalNavigationTool.InvokeAsync`, and `NavigateToRootTool.InvokeAsync` are all inherently async and delegate to async `HttpClient` extension methods.
+
+---
+
+### CancellationToken threading (REQ-38)
+
+Every async call site passes the `CancellationToken` received from the framework:
+- `HalMcpStartupService.StartAsync` receives `CancellationToken` from `IHostedService.StartAsync` and passes it to `GetHalAsync`
+- `HalNavigationTool.InvokeAsync` receives `CancellationToken` from `McpServerTool.InvokeAsync(RequestContext, CancellationToken)` and passes it to `GetHalAsync`
+- `NavigateToRootTool.InvokeAsync` receives `CancellationToken` from the same `McpServerTool` contract and passes it to `GetHalAsync`
+
+The `CancellationToken` is not stored as a field. It flows through the call chain as a parameter at every level.
+
+---
+
+### Parallelism (REQ-39)
+
+No parallelism is needed in this package. Each tool invocation performs a single HTTP GET. `SwapTools` is a synchronous in-memory collection mutation. There are no loops performing independent async I/O calls, so `Task.WhenAll` is not applicable.
 
 ---
 
@@ -614,3 +639,10 @@ Request bodies, response bodies, auth headers, and API keys must never appear in
 - Verify Trace-level tool-name loop does not execute when Trace logging is disabled (confirms `IsEnabled` guard works)
 - Verify no log calls throw when a `NullLogger<T>` is used
 - Use `Microsoft.Extensions.Logging.Testing.FakeLogger<T>` or a mock `ILogger<T>` to assert log level, event ID, and message content
+
+### Async conventions
+
+- Verify `CancellationToken` is passed through to `GetHalAsync` in `HalNavigationTool.InvokeAsync` (mock `HttpClient` asserts token received)
+- Verify `CancellationToken` is passed through to `GetHalAsync` in `NavigateToRootTool.InvokeAsync`
+- Verify `CancellationToken` is passed through to `GetHalAsync` in `HalMcpStartupService.StartAsync`
+- Verify cancellation is honored: when a pre-cancelled token is supplied, the operation throws `OperationCanceledException` without making an HTTP request

--- a/docs/mcp/architecture.md
+++ b/docs/mcp/architecture.md
@@ -434,6 +434,116 @@ When returning HAL resource content in `CallToolResult`, the resource is seriali
 
 ---
 
+## Logging Architecture
+
+### ILogger<T> Injection
+
+Each stateful type accepts `ILogger<T>` via constructor injection (REQ-24). Updated constructor signatures:
+
+```csharp
+public sealed class HalMcpStartupService : IHostedService
+{
+    public HalMcpStartupService(
+        McpServerOptions mcpOptions,
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        ILogger<HalMcpStartupService> logger);
+}
+
+public sealed class HalNavigationTool : McpServerTool
+{
+    public HalNavigationTool(
+        string rel,
+        LinkObject link,
+        string selfHref,
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        McpServerOptions mcpOptions,
+        ILogger<HalNavigationTool> logger);
+}
+
+public sealed class NavigateToRootTool : McpServerTool
+{
+    public NavigateToRootTool(
+        HttpClient httpClient,
+        HalMcpServerOptions halOptions,
+        McpServerOptions mcpOptions,
+        ILogger<NavigateToRootTool> logger);
+}
+```
+
+**`HalToolCollectionManager` (internal static):** Does not accept `ILogger`. It is a pure collection-mutation helper. All logging for tool-swap operations is performed at the call site (the tool or startup service that calls `SwapTools`), which has richer context (which tool triggered the swap, the root URI, the current navigation href). Injecting a logger into a static helper would make it impure and reduce testability without improving log quality.
+
+**`HalMcpServerBuilderExtensions.WithHalApi`:** Runs during service registration before the DI container is built, so `ILogger` is unavailable at this stage. The configured-root-uri `Debug` log is deferred to `HalMcpStartupService.StartAsync` instead. If `RootUri` validation fails, `ArgumentException` is thrown without logging — the exception message is descriptive, and the caller's exception handler is the appropriate place to log it.
+
+---
+
+### LoggerMessage Source Generators
+
+All log points are defined as `[LoggerMessage]` attributed static partial methods (REQ-35). Event IDs are scoped per category (per type).
+
+**`HalMcpStartupService` log points:**
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogConfiguredRootUri` | Debug | 1 | `"Configured RootUri: {RootUri}"` | `RootUri` |
+| `LogStartupFetchBegin` | Debug | 2 | `"Fetching root resource from {RootUri}"` | `RootUri` |
+| `LogStartupComplete` | Information | 3 | `"HAL MCP tools initialized: {ToolCount} tools registered from {RootUri}"` | `ToolCount`, `RootUri` |
+| `LogStartupFailed` | Warning | 4 | `"Failed to fetch root resource from {RootUri} on startup"` | `RootUri` (exception passed as `Exception` arg) |
+
+**`HalNavigationTool` log points:**
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogToolInvoking` | Debug | 1 | `"Invoking tool '{ToolName}', fetching {Href}"` | `ToolName`, `Href` |
+| `LogToolResponse` | Debug | 2 | `"Tool '{ToolName}' received {StatusCode} from {Href}"` | `ToolName`, `StatusCode`, `Href` |
+| `LogToolHttpError` | Warning | 3 | `"Tool '{ToolName}' received HTTP {StatusCode} from {Href}"` | `ToolName`, `StatusCode`, `Href` |
+| `LogToolNonHalResponse` | Warning | 4 | `"Tool '{ToolName}' received non-HAL response from {Href}"` | `ToolName`, `Href` |
+| `LogToolException` | Error | 5 | `"Tool '{ToolName}' failed"` | `ToolName` (exception passed as `Exception` arg) |
+| `LogToolsSwapped` | Debug | 6 | `"Tool collection updated: {RemovedCount} removed, {AddedCount} added"` | `RemovedCount`, `AddedCount` |
+| `LogToolAdded` | Trace | 7 | `"Tool added: {AddedToolName}"` | `AddedToolName` |
+
+**`NavigateToRootTool` log points:**
+
+| Log method | Level | Event ID | Message template | Parameters |
+|---|---|---|---|---|
+| `LogRootInvoking` | Debug | 1 | `"Navigating to root {RootUri}"` | `RootUri` |
+| `LogRootResponse` | Debug | 2 | `"Root navigation received {StatusCode} from {RootUri}"` | `StatusCode`, `RootUri` |
+| `LogRootNonHalResponse` | Warning | 3 | `"Root resource at {RootUri} was not a valid HAL resource"` | `RootUri` |
+| `LogRootException` | Error | 4 | `"Root navigation failed"` | (exception passed as `Exception` arg) |
+| `LogRootToolsSwapped` | Debug | 5 | `"Root tool collection updated: {RemovedCount} removed, {AddedCount} added"` | `RemovedCount`, `AddedCount` |
+| `LogRootToolAdded` | Trace | 6 | `"Tool added: {AddedToolName}"` | `AddedToolName` |
+
+---
+
+### SwapTools Call-Site Logging Pattern
+
+The calling tool or startup service logs before and after calling `SwapTools`. The Trace-level tool-name loop uses an explicit `IsEnabled` guard (REQ-33):
+
+```
+var previousCount = _mcpOptions.ToolCollection.Count;
+HalToolCollectionManager.SwapTools(
+    _mcpOptions.ToolCollection, response, resolvedHref,
+    _halOptions, _httpClient, _mcpOptions);
+var addedCount = _mcpOptions.ToolCollection.Count - 1; // minus navigate_to_root
+LogToolsSwapped(previousCount - 1, addedCount);
+
+if (_logger.IsEnabled(LogLevel.Trace))
+    foreach (var tool in _mcpOptions.ToolCollection)
+        if (tool.ProtocolTool.Name != "navigate_to_root")
+            LogToolAdded(tool.ProtocolTool.Name);
+```
+
+The `-1` adjusts for the persistent `navigate_to_root` tool, which is not counted in the "removed" or "added" totals.
+
+---
+
+### Sensitive Data
+
+Request bodies, response bodies, auth headers, and API keys must never appear in log messages (REQ-36). Tool names and hrefs are safe to log.
+
+---
+
 ## Test Strategy
 
 ### Unit tests
@@ -494,3 +604,13 @@ When returning HAL resource content in `CallToolResult`, the resource is seriali
 - Start at root -> navigate to sub-resource -> navigate to child -> return to root
 - Verify tool collection updates correctly at each step
 - Verify content returned at each step matches the fetched resource
+
+### Logging
+
+- Verify `HalMcpStartupService` emits `Information` with tool count on successful startup
+- Verify `HalMcpStartupService` emits `Warning` (not `Error`) when root fetch fails on startup
+- Verify `HalNavigationTool.InvokeAsync` emits `Debug` before fetch, `Warning` on HTTP error, `Warning` on non-HAL response, `Error` on exception
+- Verify `NavigateToRootTool.InvokeAsync` follows the same pattern
+- Verify Trace-level tool-name loop does not execute when Trace logging is disabled (confirms `IsEnabled` guard works)
+- Verify no log calls throw when a `NullLogger<T>` is used
+- Use `Microsoft.Extensions.Logging.Testing.FakeLogger<T>` or a mock `ILogger<T>` to assert log level, event ID, and message content

--- a/docs/mcp/requirements.md
+++ b/docs/mcp/requirements.md
@@ -127,6 +127,34 @@ Examples:
 
 **REQ-23:** `MaxDepth` traversal limiting is not implemented. The agent may traverse indefinitely.
 
+### Logging
+
+**REQ-24:** `HalMcpStartupService`, `HalNavigationTool`, and `NavigateToRootTool` each accept `ILogger<T>` via constructor injection. `HalToolCollectionManager` is an internal static helper and does not hold an `ILogger`; logging for tool-swap operations is performed at the call site (the tool or startup service that calls `SwapTools`), which has richer context about the triggering event.
+
+**REQ-25:** All log messages use structured logging with named placeholders (e.g., `{ToolName}`, `{Href}`, `{StatusCode}`, `{ToolCount}`, `{RootUri}`, `{Rel}`) and never string concatenation or string interpolation in log calls.
+
+**REQ-26:** At `Information` level, `HalMcpStartupService` logs one message on successful root fetch and tool registration, including the number of tools registered and the root URI. This is the only `Information`-level log in the package.
+
+**REQ-27:** At `Warning` level, `HalMcpStartupService` logs when the root fetch fails on startup, including the exception and the root URI. Startup does not throw (per REQ-03).
+
+**REQ-28:** At `Debug` level, `HalNavigationTool.InvokeAsync` logs the tool name and resolved href before each HTTP fetch, and the response status code after receiving the response.
+
+**REQ-29:** At `Warning` level, `HalNavigationTool.InvokeAsync` logs when the HTTP response is a non-success status code, including the status code and resolved href.
+
+**REQ-30:** At `Warning` level, `HalNavigationTool.InvokeAsync` logs when the response is not a valid HAL resource, including the resolved href.
+
+**REQ-31:** At `Error` level, `HalNavigationTool.InvokeAsync` logs unexpected exceptions during tool invocation, including the exception and the tool name.
+
+**REQ-32:** `NavigateToRootTool.InvokeAsync` follows the same logging pattern as `HalNavigationTool` (REQ-28 through REQ-31) using its own `ILogger<NavigateToRootTool>`.
+
+**REQ-33:** At `Debug` level, after `SwapTools` completes, the calling tool or startup service logs the number of tools removed and the number of tools added. At `Trace` level, each individual tool name added to the collection is logged inside an `IsEnabled(LogLevel.Trace)` guard to avoid iteration overhead when `Trace` is not enabled.
+
+**REQ-34:** At `Debug` level, `HalMcpStartupService.StartAsync` logs the configured `RootUri` before fetching. Because `WithHalApi` runs during service registration before the DI container is built, the configured-root-uri log is deferred to `HalMcpStartupService.StartAsync` rather than emitted from `WithHalApi` directly. If `RootUri` validation fails in `WithHalApi`, the `ArgumentException` is thrown without logging — the exception message is descriptive and the caller's exception handler is the correct place to log it.
+
+**REQ-35:** All `Debug`-level log points use `LoggerMessage` source generators to avoid string allocation when `Debug` logging is not enabled. All `Trace`-level log points that iterate collections use explicit `IsEnabled(LogLevel.Trace)` guards before the loop. No `Information`-level logging occurs on hot paths (only on startup).
+
+**REQ-36:** Request bodies, response bodies, auth headers, and API keys must never appear in log messages at any log level. Tool names and hrefs are safe to log.
+
 ---
 
 ## Integration Story

--- a/docs/mcp/requirements.md
+++ b/docs/mcp/requirements.md
@@ -155,6 +155,14 @@ Examples:
 
 **REQ-36:** Request bodies, response bodies, auth headers, and API keys must never appear in log messages at any log level. Tool names and hrefs are safe to log.
 
+### Async and Cancellation
+
+**REQ-37:** All I/O operations in `Chatter.Rest.Hal.Mcp` must be async end-to-end. Synchronous-over-async patterns (`.Result`, `.GetAwaiter().GetResult()`, `.Wait()`) and blocking calls (`Thread.Sleep`) are prohibited anywhere in the implementation. `HalMcpStartupService.StartAsync`, `HalNavigationTool.InvokeAsync`, and `NavigateToRootTool.InvokeAsync` are all inherently async and must remain fully async through all delegate calls.
+
+**REQ-38:** Every async method that performs or delegates to I/O must accept a `CancellationToken` parameter and pass it through to all downstream async calls. Specifically: `HalMcpStartupService.StartAsync` receives `CancellationToken` from the `IHostedService` contract and must pass it to `GetHalAsync`. `HalNavigationTool.InvokeAsync` and `NavigateToRootTool.InvokeAsync` receive `CancellationToken` from the `McpServerTool.InvokeAsync(RequestContext, CancellationToken)` base-class contract and must pass it to `GetHalAsync`. The `CancellationToken` is not stored as a field — it flows as a call-chain parameter at every level.
+
+**REQ-39:** Tool invocation in this package is single-resource-fetch-per-call. There are no loops performing independent async I/O calls, so `Task.WhenAll` parallelism is not applicable. This requirement documents the analysis explicitly so that future maintainers do not introduce unnecessary parallelism.
+
 ---
 
 ## Integration Story


### PR DESCRIPTION
## Summary

- **`docs/client/requirements.md`** — REQ-46–48: async-only I/O rule, CancellationToken threading rule, `Task.WhenAll` for independent parallel fetches (`FollowLinks`). Updates the "Follow array-valued links" behavioral scenario from sequential to concurrent.
- **`docs/client/architecture.md`** — Rewrites `FollowLinks` flow from sequential `yield return await` to parallel `Task.WhenAll` + buffered yield. Adds `## Async Conventions` section (between Serialization and Logging Architecture) covering all three async rules with specific threading points. Adds concurrency test point.
- **`docs/mcp/requirements.md`** — REQ-37–39: async-only I/O, CancellationToken threading (explicit callouts for `StartAsync`, `HalNavigationTool.InvokeAsync`, `NavigateToRootTool.InvokeAsync`), and explicit no-parallelism analysis.
- **`docs/mcp/architecture.md`** — Fixes three `GetHalAsync` pseudocode call sites missing `cancellationToken`. Adds `## Async Conventions` section. Adds `### Async conventions` test subsection.

> **Note:** This branch is based on `docs/add-logging-requirements` (PR #69) to preserve correct REQ numbering continuity. It should be merged after PR #69.

## Test plan

- [ ] REQ-46–48 present and numbered correctly after REQ-45 in `docs/client/requirements.md`
- [ ] REQ-37–39 present and numbered correctly after REQ-36 in `docs/mcp/requirements.md`
- [ ] `FollowLinks` flow in client architecture shows `Task.WhenAll` (not sequential await)
- [ ] All three `GetHalAsync` call sites in MCP architecture pass `cancellationToken`
- [ ] `## Async Conventions` sections in both architecture files are between `## Serialization` and `## Logging Architecture`
- [ ] No existing REQ entries or other content modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)