### PR TITLE
docs(aspnetcore): add Chatter.Rest.Hal.AspNetCore requirements and architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Chatter.Rest.Hal is a .NET/C# implementation of the HAL (Hypertext Application L
 | [docs/usage.md](docs/usage.md) | Copy-paste examples for building, serializing, deserializing |
 | [docs/development.md](docs/development.md) | Build/test/pack commands, code style, test conventions, CI/CD |
 | [docs/HAL_TEST_PLAN.md](docs/HAL_TEST_PLAN.md) | Spec-to-test mapping; consult when adding tests or evaluating spec compliance |
+| [docs/aspnetcore/requirements.md](docs/aspnetcore/requirements.md) | Package requirements (REQ-01–REQ-37) for `Chatter.Rest.Hal.AspNetCore` |
+| [docs/aspnetcore/architecture.md](docs/aspnetcore/architecture.md) | Architecture, type pseudocode, and test strategy for `Chatter.Rest.Hal.AspNetCore` |
 
 ## Solution Structure
 

--- a/docs/aspnetcore/architecture.md
+++ b/docs/aspnetcore/architecture.md
@@ -1,0 +1,628 @@
+# Chatter.Rest.Hal.AspNetCore -- Architecture
+
+This document describes how `Chatter.Rest.Hal.AspNetCore` is built. For what it does, see [requirements.md](requirements.md).
+
+---
+
+## Package Dependency Graph
+
+```
+Chatter.Rest.Hal.AspNetCore
+├── Chatter.Rest.Hal          (core HAL types: Resource, LinkObject, LinkCollection, ...)
+└── Microsoft.AspNetCore.App  (framework reference: LinkGenerator, IActionResult, IResult, ...)
+```
+
+---
+
+## Project Location
+
+```
+src/Chatter.Rest.Hal.AspNetCore/
+├── Chatter.Rest.Hal.AspNetCore.csproj
+├── HalOptions.cs
+├── HalResult.cs
+├── HalResults.cs
+├── HalControllerBase.cs
+├── HalProblem.cs
+├── IHalLinkBuilder.cs
+├── ServiceCollectionExtensions.cs
+├── MvcBuilderExtensions.cs
+├── ApplicationBuilderExtensions.cs
+├── ControllerBaseExtensions.cs
+├── ControllerLinkBuilderExtensions.cs
+├── EndpointConventionExtensions.cs
+└── Internal/
+    ├── HalLinkBuilder.cs
+    ├── AutoSelfEndpointFilter.cs
+    ├── AutoSelfResultFilter.cs
+    ├── HalExceptionHandler.cs
+    ├── HalFormatterPatcher.cs
+    ├── DisableHalAutoSelf.cs
+    └── HalRegistrationMarker.cs
+```
+
+---
+
+## Namespaces
+
+| Namespace | Visibility | Contents |
+|---|---|---|
+| `Chatter.Rest.Hal.AspNetCore` | Public | `HalOptions`, `HalResult`, `HalResults`, `HalControllerBase`, `IHalLinkBuilder`, `HalProblem`, `ServiceCollectionExtensions`, `MvcBuilderExtensions`, `ApplicationBuilderExtensions`, `ControllerBaseExtensions`, `ControllerLinkBuilderExtensions`, `EndpointConventionExtensions` |
+| `Chatter.Rest.Hal.AspNetCore.Internal` | Internal | `HalLinkBuilder`, `AutoSelfEndpointFilter`, `AutoSelfResultFilter`, `HalExceptionHandler`, `HalFormatterPatcher`, `DisableHalAutoSelf`, `HalRegistrationMarker` |
+
+A single `using Chatter.Rest.Hal.AspNetCore;` exposes all public types (REQ-05, REQ-10, REQ-15).
+
+---
+
+## Key Types
+
+### `HalOptions`
+
+Configuration root for the package. All components resolve `IOptions<HalOptions>` at runtime — no static singletons (REQ-05, REQ-10).
+
+```csharp
+public sealed class HalOptions
+{
+    /// <summary>
+    /// When true, auto-self injection filters are globally active. Default: false. (REQ-06)
+    /// </summary>
+    public bool AutoSelfLink { get; set; } = false;
+
+    /// <summary>
+    /// When true, AddHal registers HalExceptionHandler as IExceptionHandler. Default: false. (REQ-07)
+    /// </summary>
+    public bool UseProblemDetails { get; set; } = false;
+
+    /// <summary>
+    /// Content-Type written on all HalResult responses. Default: "application/hal+json". (REQ-08)
+    /// </summary>
+    public string MediaType { get; set; } = "application/hal+json";
+
+    /// <summary>
+    /// Registers a custom exception-to-problem mapping. Most-derived type wins. (REQ-09)
+    /// </summary>
+    public HalOptions MapException<TException>(Func<TException, HalProblem> map)
+        where TException : Exception;
+
+    // Internal: populated by MapException<T>. Key = exception Type, Value = mapping delegate.
+    internal Dictionary<Type, Func<Exception, HalProblem>> ExceptionMappings { get; }
+}
+```
+
+### `IHalLinkBuilder`
+
+DI-injectable abstraction for resolving route names to `LinkObject` instances via ASP.NET Core's `LinkGenerator`. Registered as singleton (REQ-11, REQ-15).
+
+```csharp
+public interface IHalLinkBuilder
+{
+    /// <summary>
+    /// Resolves routeName to a concrete href via LinkGenerator. (REQ-11)
+    /// </summary>
+    LinkObject For(string routeName, object? routeValues = null);
+
+    /// <summary>
+    /// Returns LinkObject with Href = route URI pattern and Templated = true. (REQ-12)
+    /// </summary>
+    LinkObject Template(string routeName);
+}
+```
+
+Note: Expression-based overloads (`For<TController>`, `Template<TController>`) are extension methods in `ControllerLinkBuilderExtensions` — not members of this interface (REQ-13, REQ-14).
+
+### `HalResult`
+
+Single result type that works in both the MVC controller pipeline (`IActionResult`) and the Minimal API pipeline (`IResult`) (REQ-16).
+
+```csharp
+public sealed class HalResult : IActionResult, IResult
+{
+    private readonly Resource _resource;
+    private readonly int _statusCode;
+
+    public HalResult(Resource resource, int statusCode);
+
+    // IResult (Minimal API pipeline)
+    public Task ExecuteAsync(HttpContext httpContext);
+
+    // IActionResult (MVC controller pipeline)
+    public Task ExecuteResultAsync(ActionContext context);
+
+    // Both delegate to the same core write logic — see Serialization Flow below.
+}
+```
+
+### `HalResults`
+
+Static factory class parallel to ASP.NET Core's built-in `Results` static class (REQ-19, REQ-20, REQ-21).
+
+```csharp
+public static class HalResults
+{
+    // HTTP 200 -- untyped (REQ-19)
+    public static HalResult Ok(Resource resource);
+
+    // HTTP 200 -- typed; resolves IHalLinkBuilder from request services (REQ-19)
+    public static HalResult Ok<T>(T state, Func<T, IHalLinkBuilder, Resource> builder);
+
+    // HTTP 201 (REQ-20)
+    public static HalResult Created(string uri, Resource resource);
+
+    // HTTP 202 (REQ-20)
+    public static HalResult Accepted(Resource resource);
+
+    // HTTP 204 (REQ-20)
+    public static HalResult NoContent();
+
+    // Problem responses -- Content-Type: application/problem+json (REQ-21)
+    public static IResult NotFound(string title, string? detail);
+    public static IResult ValidationProblem(IDictionary<string, string[]> errors);
+    public static IResult Problem(int statusCode, string title, string? detail);
+}
+```
+
+### `HalControllerBase`
+
+Optional abstract base class. Adds no behavior beyond re-exposing extension methods from `ControllerBaseExtensions` as `protected` convenience members (REQ-23).
+
+```csharp
+public abstract class HalControllerBase : ControllerBase
+{
+    protected HalResult HalOk(Resource resource)
+        => this.HalOk(resource);  // delegates to ControllerBaseExtensions
+
+    protected HalResult HalOk<T>(T state, Func<T, IHalLinkBuilder, Resource> builder)
+        => this.HalOk(state, builder);  // resolves IHalLinkBuilder from HttpContext.RequestServices
+
+    protected HalResult HalCreated(string uri, Resource resource);
+    protected HalResult HalAccepted(Resource resource);
+    protected IActionResult HalNoContent();
+    protected IActionResult HalNotFound(string title, string? detail);
+    protected IActionResult HalValidationProblem(IDictionary<string, string[]> errors);
+    protected IActionResult HalProblem(int statusCode, string title, string? detail);
+}
+```
+
+### `HalProblem`
+
+Static factory for RFC 9457 problem responses. Internally backed by `HalProblemPayload` — an internal record that serializes as a compliant `application/problem+json` document (REQ-33).
+
+```csharp
+public static class HalProblem
+{
+    public static HalProblem NotFound(string title, string? detail);
+    public static HalProblem Conflict(string title, string? detail);
+    public static HalProblem ValidationProblem(IDictionary<string, string[]> errors);
+    public static HalProblem Problem(int statusCode, string title, string? detail);
+}
+
+// Internal serialization payload -- RFC 9457
+internal sealed record HalProblemPayload
+{
+    public string? Type    { get; init; }    // URI identifying problem type
+    public string  Title   { get; init; }    // short human-readable summary
+    public int     Status  { get; init; }    // HTTP status code
+    public string? Detail  { get; init; }    // human-readable explanation
+    public IDictionary<string, string[]>? Errors { get; init; }  // validation errors
+}
+```
+
+### `ServiceCollectionExtensions`
+
+Entry point for registration in Minimal API and generic host applications (REQ-01, REQ-03). See Registration Sequence below for the full pseudocode.
+
+```csharp
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddHal(
+        this IServiceCollection services,
+        Action<HalOptions> configure);
+}
+```
+
+### `MvcBuilderExtensions`
+
+Entry point for registration when MVC is already configured (REQ-02). Delegates to `services.AddHal()`.
+
+```csharp
+public static class MvcBuilderExtensions
+{
+    public static IMvcBuilder AddHal(
+        this IMvcBuilder builder,
+        Action<HalOptions> configure);
+}
+```
+
+### `ApplicationBuilderExtensions`
+
+Activates the exception-handling middleware pipeline (REQ-04, REQ-30).
+
+```csharp
+public static class ApplicationBuilderExtensions
+{
+    public static IApplicationBuilder UseHal(this IApplicationBuilder app);
+}
+```
+
+### `ControllerBaseExtensions`
+
+Extension methods on `ControllerBase`. No inheritance required (REQ-22, REQ-24).
+
+```csharp
+public static class ControllerBaseExtensions
+{
+    public static HalResult HalOk(this ControllerBase controller, Resource resource);
+
+    // Resolves IHalLinkBuilder from HttpContext.RequestServices (REQ-24)
+    public static HalResult HalOk<T>(
+        this ControllerBase controller,
+        T state,
+        Func<T, IHalLinkBuilder, Resource> builder);
+
+    public static HalResult HalCreated(this ControllerBase controller, string uri, Resource resource);
+    public static HalResult HalAccepted(this ControllerBase controller, Resource resource);
+    public static IActionResult HalNoContent(this ControllerBase controller);
+    public static IActionResult HalNotFound(this ControllerBase controller, string title, string? detail);
+    public static IActionResult HalValidationProblem(this ControllerBase controller, IDictionary<string, string[]> errors);
+    public static IActionResult HalProblem(this ControllerBase controller, int statusCode, string title, string? detail);
+}
+```
+
+### `ControllerLinkBuilderExtensions`
+
+Expression-based overloads of `For` and `Template` on `IHalLinkBuilder`. Resolves route names by reflecting on controller action attributes (REQ-13, REQ-14).
+
+```csharp
+public static class ControllerLinkBuilderExtensions
+{
+    // Resolves route name from [ActionName]/[HttpGet]/[Route], extracts args, delegates to For()
+    public static LinkObject For<TController>(
+        this IHalLinkBuilder builder,
+        Expression<Action<TController>> action)
+        where TController : ControllerBase;
+
+    public static LinkObject For<TController>(
+        this IHalLinkBuilder builder,
+        Expression<Func<TController, IActionResult>> action)
+        where TController : ControllerBase;
+
+    // Resolves route name, delegates to Template()
+    public static LinkObject Template<TController>(
+        this IHalLinkBuilder builder,
+        Expression<Action<TController>> action)
+        where TController : ControllerBase;
+}
+```
+
+### `EndpointConventionExtensions`
+
+Per-endpoint auto-self overrides (REQ-28).
+
+```csharp
+public static class EndpointConventionExtensions
+{
+    // Forces auto-self injection for this endpoint regardless of global setting
+    public static IEndpointConventionBuilder WithHalAutoSelf(
+        this IEndpointConventionBuilder builder);
+
+    // Suppresses auto-self injection for this endpoint regardless of global setting
+    public static IEndpointConventionBuilder WithoutHalAutoSelf(
+        this IEndpointConventionBuilder builder);
+}
+```
+
+---
+
+## Internal Types
+
+### `HalLinkBuilder`
+
+Concrete implementation of `IHalLinkBuilder`. Sealed. Depends on `LinkGenerator` and `IHttpContextAccessor` (REQ-11, REQ-12, REQ-15).
+
+```csharp
+internal sealed class HalLinkBuilder : IHalLinkBuilder
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public HalLinkBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor);
+
+    public LinkObject For(string routeName, object? routeValues = null)
+    {
+        // Calls linkGenerator.GetPathByName(httpContext, routeName, routeValues)
+        // Throws InvalidOperationException if result is null
+        // Returns new LinkObject { Href = resolvedPath }
+    }
+
+    public LinkObject Template(string routeName)
+    {
+        // Retrieves route URI pattern for routeName from endpoint data source
+        // Returns new LinkObject { Href = pattern, Templated = true }
+    }
+}
+```
+
+### `AutoSelfEndpointFilter`
+
+`IEndpointFilter` implementation for Minimal API auto-self injection (REQ-25, REQ-26, REQ-27, REQ-28, REQ-29).
+
+```csharp
+internal sealed class AutoSelfEndpointFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(EndpointFilterInvocationContext ctx, EndpointFilterDelegate next)
+    {
+        // if endpoint metadata has DisableHalAutoSelf: return await next(ctx)
+        // result = await next(ctx)
+        // if result is HalResult and resource has no "self" link:
+        //     routeName  = ctx.HttpContext.GetEndpoint()?.DisplayName
+        //     routeValues = ctx.HttpContext.Request.RouteValues
+        //     selfLink = _linkBuilder.For(routeName, routeValues)
+        //     resource.Links.Add("self", selfLink)
+        // return result
+    }
+}
+```
+
+### `AutoSelfResultFilter`
+
+`IResultFilter` implementation for MVC controller auto-self injection (REQ-25, REQ-26, REQ-27, REQ-28, REQ-29).
+
+```csharp
+internal sealed class AutoSelfResultFilter : IResultFilter
+{
+    public void OnResultExecuting(ResultExecutingContext context)
+    {
+        // if context.Result is not HalResult: return
+        // if endpoint metadata has DisableHalAutoSelf: return
+        // if resource already has "self" link: return
+        // routeName   = context.ActionDescriptor.AttributeRouteInfo?.Name
+        // routeValues = context.RouteData.Values
+        // selfLink = _linkBuilder.For(routeName, routeValues)
+        // resource.Links.Add("self", selfLink)
+    }
+
+    public void OnResultExecuted(ResultExecutedContext context) { }
+}
+```
+
+### `HalExceptionHandler`
+
+`IExceptionHandler` implementation for RFC 9457 Problem Details responses (REQ-30, REQ-31, REQ-32, REQ-34).
+
+```csharp
+internal sealed class HalExceptionHandler : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        // Walk exception type hierarchy against _options.Value.ExceptionMappings
+        //   (most-derived registered type first)
+        // On match:
+        //   problem = mapping(exception)
+        //   httpContext.Response.StatusCode = problem.Status
+        //   httpContext.Response.ContentType = "application/problem+json"
+        //   await httpContext.Response.WriteAsJsonAsync(problem.Payload, cancellationToken)
+        //   return true
+        // No match:
+        //   write HTTP 500 HalProblem.Problem(500, "Internal Server Error", null)
+        //   return true
+    }
+}
+```
+
+### `HalFormatterPatcher`
+
+Static utility that patches ASP.NET Core's STJ output formatter to support `application/hal+json` content negotiation (REQ-36).
+
+```csharp
+internal static class HalFormatterPatcher
+{
+    public static void PatchOutputFormatter(MvcOptions options)
+    {
+        // Find SystemTextJsonOutputFormatter in options.OutputFormatters
+        // Add "application/hal+json" to its SupportedMediaTypes if not already present
+    }
+}
+```
+
+### `DisableHalAutoSelf`
+
+Internal sealed record used as an endpoint metadata marker. Presence suppresses auto-self injection for the decorated endpoint (REQ-28).
+
+```csharp
+internal sealed record DisableHalAutoSelf;
+```
+
+### `HalRegistrationMarker`
+
+Internal sealed class used as a DI sentinel for idempotent registration. `AddHal` returns immediately if this type is already registered (REQ-03).
+
+```csharp
+internal sealed class HalRegistrationMarker;
+```
+
+---
+
+## Registration Sequence
+
+`ServiceCollectionExtensions.AddHal` executes the following sequence (REQ-01, REQ-03, REQ-05, REQ-06, REQ-07):
+
+```
+AddHal(IServiceCollection services, Action<HalOptions> configure):
+    if services has HalRegistrationMarker:
+        return services                                     // idempotent guard (REQ-03)
+
+    services.AddSingleton<HalRegistrationMarker>()
+
+    services.Configure<HalOptions>(configure)              // -> IOptions<HalOptions> (REQ-05)
+    services.AddHttpContextAccessor()
+    services.AddSingleton<IHalLinkBuilder, HalLinkBuilder>()
+
+    // Minimal API pipeline -- always registered
+    services.Configure<JsonOptions>(o =>
+        o.JsonSerializerOptions.AddHalConverters())        // HAL converters for HttpJsonOptions
+
+    // MVC pipeline -- registered only when MVC is present
+    if services has IApiDescriptionGroupCollectionProvider:
+        services.Configure<MvcOptions>(o =>
+            HalFormatterPatcher.PatchOutputFormatter(o))   // application/hal+json content negotiation (REQ-36)
+        services.Configure<MvcJsonOptions>(o =>
+            o.JsonSerializerOptions.AddHalConverters())    // HAL converters for MVC JsonOptions
+
+    // Auto-self filter -- wired after options are configured (REQ-06, REQ-29)
+    services.AddOptions<HalOptions>().PostConfigure(opts =>
+        if opts.AutoSelfLink:
+            services.AddScoped<IResultFilter, AutoSelfResultFilter>())
+
+    // UseProblemDetails -- IExceptionHandler registered here; middleware activated by UseHal() (REQ-07, REQ-30)
+    if configure sets UseProblemDetails = true:
+        services.AddExceptionHandler<HalExceptionHandler>()
+
+    return services
+```
+
+`MvcBuilderExtensions.AddHal` delegates directly:
+
+```
+AddHal(IMvcBuilder builder, Action<HalOptions> configure):
+    builder.Services.AddHal(configure)
+    return builder
+```
+
+`ApplicationBuilderExtensions.UseHal` activates the middleware pipeline:
+
+```
+UseHal(IApplicationBuilder app):
+    app.UseExceptionHandler()    // activates IExceptionHandler pipeline (REQ-04, REQ-30)
+    return app
+```
+
+---
+
+## HalResult Serialization Flow
+
+Both `ExecuteAsync` (Minimal API) and `ExecuteResultAsync` (MVC) delegate to the same core write logic (REQ-16, REQ-17, REQ-18, REQ-35):
+
+```
+CoreWriteAsync(HttpContext context):
+    context.Response.StatusCode  = _statusCode
+    context.Response.ContentType = _options.Value.MediaType          // e.g. "application/hal+json"
+
+    jsonOptions = context.RequestServices
+        .GetRequiredService<IOptions<JsonOptions>>()
+        .Value.JsonSerializerOptions                                  // HAL-aware options from DI
+
+    await context.Response.WriteAsJsonAsync(_resource, jsonOptions)  // direct stream write (REQ-17)
+```
+
+The MVC path (`ExecuteResultAsync`) extracts `HttpContext` from `ActionContext.HttpContext` before delegating.
+
+---
+
+## Auto-Self Injection Flow
+
+### Minimal API (`AutoSelfEndpointFilter`)
+
+```
+InvokeAsync(EndpointFilterInvocationContext ctx, EndpointFilterDelegate next):
+    if ctx.HttpContext.GetEndpoint()?.Metadata.GetMetadata<DisableHalAutoSelf>() is not null:
+        return await next(ctx)                                        // suppressed (REQ-28)
+
+    result = await next(ctx)
+
+    if result is HalResult halResult and halResult.Resource.Links["self"] is null:
+        routeName   = ctx.HttpContext.GetEndpoint()?.DisplayName
+        routeValues = ctx.HttpContext.Request.RouteValues
+        selfLink    = _linkBuilder.For(routeName, routeValues)
+        halResult.Resource.Links.Add("self", selfLink)                // inject (REQ-25, REQ-26)
+
+    return result
+```
+
+### Controller (`AutoSelfResultFilter`)
+
+```
+OnResultExecuting(ResultExecutingContext context):
+    if context.Result is not HalResult halResult:
+        return
+
+    if context.HttpContext.GetEndpoint()?.Metadata.GetMetadata<DisableHalAutoSelf>() is not null:
+        return                                                        // suppressed (REQ-28)
+
+    if halResult.Resource.Links["self"] is not null:
+        return                                                        // already present (REQ-27)
+
+    routeName   = context.ActionDescriptor.AttributeRouteInfo?.Name
+    routeValues = context.RouteData.Values
+    selfLink    = _linkBuilder.For(routeName, routeValues)
+    halResult.Resource.Links.Add("self", selfLink)                    // inject (REQ-25, REQ-26)
+```
+
+---
+
+## Expression Resolution
+
+`ControllerLinkBuilderExtensions.For<TController>` resolves a route name and route values from an expression tree (REQ-13, REQ-14):
+
+```
+For<TController>(Expression<Action<TController>> action):
+1. Cast action.Body to MethodCallExpression; get MethodInfo
+2. Check [ActionName] attribute on method -> use .Name as routeName
+3. Else check [HttpGet/Post/Put/Patch/Delete] attribute Name property -> use as routeName
+4. Else check [Route] attribute Name property -> use as routeName
+5. Else use method.Name as convention fallback
+6. Extract route values:
+   For each argument expression in MethodCallExpression.Arguments:
+     - ConstantExpression -> use .Value directly
+     - MemberExpression (captured closure) -> compile and invoke lambda to get value
+     - Other -> throw InvalidOperationException("Expression argument not supported")
+   Build RouteValueDictionary from parameter name -> value pairs
+7. Delegate to _builder.For(routeName, routeValues)
+```
+
+Limitation: Only constant values and captured closures are supported in expression arguments. Method calls and complex expressions will throw `InvalidOperationException`.
+
+---
+
+## Error Handling Summary
+
+| Condition | Behavior | REQ |
+|---|---|---|
+| Exception matches `MapException<T>` | Custom problem response; `Content-Type: application/problem+json` | REQ-31, REQ-34 |
+| Exception not matched | HTTP 500 `application/problem+json` response | REQ-31 |
+| `LinkGenerator` cannot resolve route name | `InvalidOperationException` thrown from `HalLinkBuilder.For` | REQ-11 |
+| Expression route name unresolvable | `InvalidOperationException` thrown from `ControllerLinkBuilderExtensions` | REQ-13 |
+| `AddHal` called multiple times | Idempotent; returns `services` immediately after first registration | REQ-03 |
+
+---
+
+## Test Strategy
+
+### Unit tests
+
+- **`HalOptions`**: verify defaults for all properties; verify `MapException<T>` stores mapping in `ExceptionMappings` keyed by `typeof(TException)`; verify most-derived type wins when multiple mappings registered
+- **`HalResult`**: verify `ExecuteAsync` sets correct status code and `Content-Type`; verify `ExecuteResultAsync` delegates to same write logic; verify `WriteAsJsonAsync` is called with the `Resource` and HAL `JsonSerializerOptions`
+- **`HalResults`**: verify each factory method returns correct HTTP status; verify `Ok<T>` resolves `IHalLinkBuilder` from service provider and passes to builder delegate
+- **`HalControllerBase` + `ControllerBaseExtensions`**: verify each method delegates to the correct `HalResults` factory; verify `HalOk<T>` resolves `IHalLinkBuilder` from `HttpContext.RequestServices`
+- **`HalProblem`**: verify each factory sets correct `Status`, `Title`, `Detail`, and `Type` URI per RFC 9457; verify `ValidationProblem` includes `Errors` in payload
+- **`HalLinkBuilder`** (internal): verify `For()` calls `LinkGenerator.GetPathByName` with correct arguments; verify `InvalidOperationException` on null result; verify `Template()` returns `LinkObject` with `Templated = true`
+- **`ControllerLinkBuilderExtensions`**: verify expression with `[ActionName]` extracts correct route name; verify expression with `[HttpGet(Name = ...)]` extracts correct route name; verify constant args produce correct route values; verify captured closure args produce correct route values; verify unsupported expression type throws `InvalidOperationException`
+- **`AutoSelfEndpointFilter`**: verify self link injected when absent and no `DisableHalAutoSelf` marker; verify injection skipped when `"self"` already present; verify injection skipped when `DisableHalAutoSelf` present
+- **`AutoSelfResultFilter`**: verify same three conditions for controller pipeline
+- **`HalExceptionHandler`**: verify matched exception type produces correct status and `Content-Type: application/problem+json`; verify unmatched exception produces HTTP 500; verify most-derived registered type wins over base type
+
+### Integration tests (`WebApplicationFactory`)
+
+- **`AddHal(IServiceCollection)`**: resolves `IHalLinkBuilder`, `IOptions<HalOptions>`, HAL converters present in `HttpJsonOptions`
+- **`AddHal(IMvcBuilder)`**: same as above plus `SystemTextJsonOutputFormatter` supports `application/hal+json`
+- **Idempotency**: double `AddHal(...)` call results in no duplicate services in DI container
+- **Minimal API end-to-end**: `GET` endpoint returns `HalResults.Ok(resource)` -> `200 OK`, `Content-Type: application/hal+json`, `_links` present in body
+- **Controller end-to-end**: `GET` action returns `HalOk(resource)` -> `200 OK`, `Content-Type: application/hal+json`, `_links` present in body
+- **Auto-self injection**: resource without `"self"` + `AutoSelfLink = true` -> `"self"` present in response `_links`
+- **Auto-self skip**: resource with existing `"self"` + `AutoSelfLink = true` -> existing link unchanged
+- **`WithoutHalAutoSelf()`**: endpoint marked with `WithoutHalAutoSelf()` -> no `"self"` injected even when global setting is `true`
+- **Problem Details -- registered exception**: `MapException<NotFoundException>` registered + endpoint throws `NotFoundException` -> `404 Not Found`, `Content-Type: application/problem+json`, RFC 9457 payload
+- **Problem Details -- fallback**: unregistered exception + `UseProblemDetails = true` -> `500 Internal Server Error`, `Content-Type: application/problem+json`
+- **Content negotiation**: controller action returns raw `Resource` + `Accept: application/hal+json` request -> response `Content-Type: application/hal+json` via patched STJ formatter

--- a/docs/aspnetcore/requirements.md
+++ b/docs/aspnetcore/requirements.md
@@ -1,0 +1,292 @@
+# Chatter.Rest.Hal.AspNetCore -- Requirements
+
+This document is the source of truth for what the `Chatter.Rest.Hal.AspNetCore` package does. Test scenarios are derived directly from the numbered requirements below. For how the system is built, see [architecture.md](architecture.md).
+
+---
+
+## Overview
+
+`Chatter.Rest.Hal.AspNetCore` is a new NuGet package that provides server-side ASP.NET Core integration for building HAL (Hypertext Application Language) APIs. It eliminates the manual wiring required to produce HAL responses from both MVC controllers and Minimal API endpoints, providing DI-friendly registration, a typed result type (`HalResult`) that works in both pipelines, a DI-injectable link builder (`IHalLinkBuilder`) backed by ASP.NET Core's `LinkGenerator`, opt-in auto-self link injection, and RFC 9457 Problem Details support via `IExceptionHandler`.
+
+### Package dependencies
+
+- `Chatter.Rest.Hal` -- core HAL types (`Resource`, `Resource<T>`, `LinkObject`, `LinkCollection`, `Link`)
+- `Microsoft.AspNetCore.App` -- ASP.NET Core framework reference (not a NuGet package; framework reference only)
+
+---
+
+## Personas
+
+### API developer
+
+Building HAL APIs in ASP.NET Core using either MVC controllers or Minimal APIs. Wants DI-friendly registration, typed HAL responses, and link generation without writing HTTP boilerplate or manual JSON wiring.
+
+### Minimal API developer
+
+Prefers `IResult`-based endpoints over `IActionResult`. Wants `HalResults` factory methods that work identically to the built-in `Results` static class and a link builder injectable directly into endpoint delegates.
+
+### Existing Chatter.Rest.Hal user
+
+Already uses `Chatter.Rest.Hal` server-side for building HAL documents. Wants to add ASP.NET Core integration to the same app with a familiar API surface and a single `using Chatter.Rest.Hal.AspNetCore;` statement.
+
+---
+
+## Functional Requirements
+
+### Registration
+
+**REQ-01:** `AddHal(Action<HalOptions>)` is an extension method on `IServiceCollection` that registers: `IHalLinkBuilder` / `HalLinkBuilder` as a singleton, `IOptions<HalOptions>`, HAL JSON converters into `HttpJsonOptions` for the Minimal API pipeline, and (when MVC is present) HAL JSON converters and `application/hal+json` media type support into MVC `JsonOptions` and `MvcOptions`.
+
+**REQ-02:** `AddHal(Action<HalOptions>)` is an extension method on `IMvcBuilder` that delegates to `services.AddHal()` and ensures MVC-specific wiring. The final DI state is identical to calling `services.AddHal()` when MVC is present.
+
+**REQ-03:** Both `AddHal` overloads are idempotent. Multiple calls register services exactly once. A private sentinel service type (`HalRegistrationMarker`) is used to detect prior registration.
+
+**REQ-04:** `UseHal()` is an extension method on `IApplicationBuilder` / `WebApplication` that registers the exception-handling middleware pipeline. It is required when `HalOptions.UseProblemDetails` is `true`. It is safe to call when `false` (no-op for error handling).
+
+**REQ-05:** All global configuration is accessed via `IOptions<HalOptions>`. No static mutable state exists. Every component resolves `IOptions<HalOptions>` at runtime via dependency injection.
+
+### HalOptions
+
+**REQ-06:** `HalOptions.AutoSelfLink` is a `bool` property with default `false`. When `true`, auto-self link injection filters are globally active for all HAL responses that lack a `"self"` link.
+
+**REQ-07:** `HalOptions.UseProblemDetails` is a `bool` property with default `false`. When `true`, `AddHal` registers `HalExceptionHandler` as an `IExceptionHandler` implementation in the DI container.
+
+**REQ-08:** `HalOptions.MediaType` is a `string` property with default `"application/hal+json"`. This value is used as the `Content-Type` on all `HalResult` responses.
+
+**REQ-09:** `HalOptions.MapException<TException>(Func<TException, HalProblem>)` registers a custom exception-to-problem mapping. Multiple mappings are supported. When an exception is handled, the most-derived registered type wins.
+
+**REQ-10:** `HalOptions` supports direct construction without DI (all properties have safe defaults) and resolution via `IOptions<HalOptions>` for DI scenarios. No property requires DI to be initialized.
+
+### IHalLinkBuilder
+
+**REQ-11:** `IHalLinkBuilder.For(string routeName, object? routeValues = null)` returns a `LinkObject` with `Href` resolved to a concrete URI via ASP.NET Core's `LinkGenerator`. Throws `InvalidOperationException` when the route name cannot be resolved.
+
+**REQ-12:** `IHalLinkBuilder.Template(string routeName)` returns a `LinkObject` with `Href` set to the route URI pattern (e.g., `/orders/{id}`) and `Templated = true`.
+
+**REQ-13:** Extension methods `For<TController>(Expression<Action<TController>>)` and `For<TController>(Expression<Func<TController, IActionResult>>)` on `IHalLinkBuilder` resolve the route name from `[HttpGet]` / `[Route]` / `[ActionName]` attributes on the target action, extract route values from the expression's arguments, and delegate to `For(routeName, routeValues)`. These extension methods are in the `Chatter.Rest.Hal.AspNetCore` namespace.
+
+**REQ-14:** `Template<TController>(Expression<Action<TController>>)` extension method on `IHalLinkBuilder` resolves the route name from action attributes using the same logic as REQ-13, then delegates to `Template(routeName)`. Same namespace as REQ-13.
+
+**REQ-15:** `IHalLinkBuilder` is registered as a singleton in the DI container. It is safe to resolve at any DI lifetime scope.
+
+### HalResult
+
+**REQ-16:** `HalResult` implements both `IActionResult` (for MVC controllers) and `IResult` (for Minimal APIs). It is a single type that works in both pipelines without specialization.
+
+**REQ-17:** `HalResult` serializes `Resource` directly via `response.WriteAsJsonAsync`. It does not rely on MVC output formatters as its primary serialization path.
+
+**REQ-18:** `HalResult` sets the response `Content-Type` to `HalOptions.MediaType` and the HTTP status code from its constructor arguments. It resolves HAL-aware `JsonSerializerOptions` from the DI container at write time.
+
+### HalResults factory
+
+**REQ-19:** `HalResults.Ok(Resource)` and `HalResults.Ok<T>(T state, Func<T, IHalLinkBuilder, Resource> builder)` return a `HalResult` with HTTP 200. The generic overload resolves `IHalLinkBuilder` from the request service provider and passes it to the builder delegate.
+
+**REQ-20:** `HalResults.Created(string uri, Resource)`, `HalResults.Accepted(Resource)`, and `HalResults.NoContent()` return a `HalResult` with HTTP 201, 202, and 204 respectively.
+
+**REQ-21:** `HalResults.NotFound(string title, string? detail)`, `HalResults.ValidationProblem(IDictionary<string, string[]> errors)`, and `HalResults.Problem(int statusCode, string title, string? detail)` return a problem result with `Content-Type: application/problem+json` (RFC 9457).
+
+### HalControllerBase and controller extensions
+
+**REQ-22:** `HalOk`, `HalCreated`, `HalAccepted`, `HalNoContent`, `HalNotFound`, `HalValidationProblem`, and `HalProblem` are extension methods on `ControllerBase`. No inheritance from `HalControllerBase` is required to use them.
+
+**REQ-23:** `HalControllerBase` is an optional abstract class that inherits `ControllerBase`. It re-exposes the factory methods from REQ-22 as `protected` members. It adds no behavior beyond the extension methods.
+
+**REQ-24:** `HalOk<T>(T state, Func<T, IHalLinkBuilder, Resource> builder)` resolves `IHalLinkBuilder` from `HttpContext.RequestServices` and passes it to the builder delegate before constructing the `HalResult`.
+
+### Auto-self link injection
+
+**REQ-25:** When `HalOptions.AutoSelfLink` is `true`, every `HalResult` response whose `Resource` does not already contain a `"self"` link gets one injected before the response is written to the HTTP stream.
+
+**REQ-26:** The injected `"self"` link is produced by calling `IHalLinkBuilder.For(currentRouteName, currentRouteValues)`, where the route name and values are derived from `HttpContext` endpoint metadata and route data.
+
+**REQ-27:** Injection is skipped when the `Resource` already contains a rel named `"self"`. Existing self links are never overwritten.
+
+**REQ-28:** `WithHalAutoSelf()` on `IEndpointConventionBuilder` forces auto-self injection for a single endpoint regardless of the global setting. `WithoutHalAutoSelf()` suppresses auto-self injection for a single endpoint regardless of the global setting. Both override `HalOptions.AutoSelfLink` at the endpoint level.
+
+**REQ-29:** Auto-self injection for Minimal API endpoints is implemented as an `IEndpointFilter`. Auto-self injection for MVC controller actions is implemented as an `IResultFilter`.
+
+### Problem Details / RFC 9457
+
+**REQ-30:** When `HalOptions.UseProblemDetails` is `true`, `AddHal` registers `HalExceptionHandler` as an `IExceptionHandler` implementation. `UseHal()` activates the exception-handling middleware pipeline that invokes registered `IExceptionHandler` instances.
+
+**REQ-31:** `HalExceptionHandler.TryHandleAsync` walks the exception type hierarchy against registered `ExceptionMappings` (most-derived type first). On a match, it writes the mapped `HalProblem` to the response and returns `true`. When no match is found, it writes a generic HTTP 500 problem response.
+
+**REQ-32:** All problem responses use `Content-Type: application/problem+json` as specified by RFC 9457. Problem responses do not include HAL `_links` or `_embedded` properties in v1.
+
+**REQ-33:** `HalProblem` provides static factory methods: `NotFound(string title, string? detail)`, `Conflict(string title, string? detail)`, `ValidationProblem(IDictionary<string, string[]> errors)`, and `Problem(int statusCode, string title, string? detail)`.
+
+**REQ-34:** Custom mappings registered via `HalOptions.MapException<T>` take precedence over built-in defaults. When multiple mappings could match, the most-derived registered exception type wins.
+
+### Serialization
+
+**REQ-35:** `HalResult` writes the response body using `response.WriteAsJsonAsync(resource, jsonOptions)` with HAL-aware `JsonSerializerOptions`. It does not delegate to MVC output formatters for this path.
+
+**REQ-36:** `AddHal` patches `SystemTextJsonOutputFormatter` to add `application/hal+json` to its list of supported media types. This enables content negotiation for controller actions that return a raw `Resource` without wrapping it in a `HalResult`.
+
+**REQ-37:** Content negotiation behavior: a request with `Accept: application/hal+json` receives a response with `Content-Type: application/hal+json` via the patched STJ formatter. A request with `Accept: application/json` receives `Content-Type: application/json` as a fallback. A `HalResult` always produces `Content-Type: application/hal+json` regardless of the `Accept` header value.
+
+---
+
+## Error Handling Summary
+
+| Scenario | Behavior |
+|---|---|
+| Exception matches `MapException<T>` | Custom problem response via mapped `HalProblem` |
+| Exception not matched, `UseProblemDetails = true` | HTTP 500 `application/problem+json` response |
+| `LinkGenerator` cannot resolve route name | Throw `InvalidOperationException` |
+| Expression route name unresolvable | Throw `InvalidOperationException` |
+| `AddHal` called multiple times | Idempotent; services registered exactly once |
+
+---
+
+## Integration Story
+
+The following shows two ways to integrate `Chatter.Rest.Hal.AspNetCore` in a .NET 8 application.
+
+### Option A -- Minimal API
+
+```csharp
+// Register HAL services
+builder.Services.AddHal(o =>
+{
+    o.AutoSelfLink = true;
+    o.UseProblemDetails = true;
+    o.MapException<NotFoundException>(ex => HalProblem.NotFound(ex.Message, null));
+});
+app.UseHal();
+
+// Endpoint
+app.MapGet("/orders/{id}", async (int id, IHalLinkBuilder links, OrderRepo repo) =>
+{
+    var order = await repo.GetAsync(id);
+    return HalResults.Ok(order, (o, lnk) => Resource.Create(o)
+        .WithLink("self",   lnk.For("orders:get", new { id }))
+        .WithLink("search", lnk.Template("orders:search")));
+}).WithName("orders:get");
+```
+
+### Option B -- MVC Controllers
+
+```csharp
+// Register HAL services alongside MVC
+builder.Services.AddControllers().AddHal(o =>
+{
+    o.AutoSelfLink = true;
+    o.UseProblemDetails = true;
+});
+
+// Controller
+[ApiController, Route("api/orders")]
+public class OrdersController(IHalLinkBuilder links) : HalControllerBase
+{
+    [HttpGet("{id}"), ActionName("orders:get")]
+    public async Task<IActionResult> Get(int id)
+    {
+        var order = await repo.GetAsync(id);
+        if (order is null) return HalNotFound("Order not found", null);
+        return HalOk(order, (o, lnk) => Resource.Create(o)
+            .WithLink("self",   lnk.For<OrdersController>(c => c.Get(id)))
+            .WithLink("cancel", lnk.For<OrdersController>(c => c.Cancel(id))));
+    }
+}
+```
+
+Both options register `IHalLinkBuilder` and `IOptions<HalOptions>` in the DI container. Option A uses Minimal API endpoint delegates. Option B uses MVC controllers with expression-based link generation.
+
+---
+
+## Behavioral Scenarios
+
+These scenarios describe end-to-end behavior for test derivation.
+
+### Scenario: Minimal API returns HAL response
+
+1. `AddHal` registered on `IServiceCollection`
+2. Endpoint calls `HalResults.Ok(order, (o, lnk) => Resource.Create(o).WithLink("self", lnk.For("orders:get", new { id })))`
+3. `HalResult.ExecuteAsync` sets status 200 and `Content-Type: application/hal+json`
+4. Response body is the JSON-serialized `Resource` with `_links`
+5. Client receives `200 OK` with `application/hal+json` and correct `_links`
+
+### Scenario: Controller returns HAL response with expression links
+
+1. `AddHal` registered on `IMvcBuilder`
+2. Controller action calls `HalOk(order, (o, lnk) => Resource.Create(o).WithLink("self", lnk.For<OrdersController>(c => c.Get(id))))`
+3. `For<OrdersController>` resolves route name from `[ActionName]` attribute, extracts `id` from expression args
+4. `IHalLinkBuilder.For(routeName, routeValues)` resolves concrete href via `LinkGenerator`
+5. Response is `200 OK` with `application/hal+json` and correct resolved `_links` hrefs
+
+### Scenario: Auto-self injected when resource has no self link
+
+1. `HalOptions.AutoSelfLink = true`
+2. Endpoint returns `HalResult` whose `Resource` has no `"self"` link
+3. `AutoSelfEndpointFilter` / `AutoSelfResultFilter` detects absence of `"self"`
+4. Filter calls `IHalLinkBuilder.For(currentRouteName, currentRouteValues)`
+5. `"self"` link is added to `Resource` before response is written
+
+### Scenario: Auto-self skipped when resource already has self link
+
+1. `HalOptions.AutoSelfLink = true`
+2. Endpoint returns `HalResult` whose `Resource` already has a `"self"` link
+3. Filter checks for `"self"` presence and finds it
+4. No injection occurs; existing `"self"` link is unchanged in the response
+
+### Scenario: Auto-self suppressed by WithoutHalAutoSelf()
+
+1. `HalOptions.AutoSelfLink = true` globally
+2. Endpoint is decorated with `.WithoutHalAutoSelf()`
+3. `DisableHalAutoSelf` metadata marker is present on the endpoint
+4. Filter reads metadata and skips injection regardless of global setting
+5. Response does not contain an injected `"self"` link
+
+### Scenario: Registered exception mapped to problem response
+
+1. `HalOptions.MapException<NotFoundException>(ex => HalProblem.NotFound(ex.Message, null))` registered
+2. `HalOptions.UseProblemDetails = true`; `UseHal()` called
+3. Endpoint throws `NotFoundException`
+4. `HalExceptionHandler.TryHandleAsync` finds mapping for `NotFoundException`
+5. Response is `404 Not Found` with `Content-Type: application/problem+json` and RFC 9457 payload
+
+### Scenario: Unregistered exception returns 500 problem response
+
+1. `HalOptions.UseProblemDetails = true`; `UseHal()` called
+2. No mapping registered for `InvalidOperationException`
+3. Endpoint throws `InvalidOperationException`
+4. `HalExceptionHandler.TryHandleAsync` finds no matching mapping
+5. Response is `500 Internal Server Error` with `Content-Type: application/problem+json`
+
+### Scenario: Template link builder returns templated LinkObject
+
+1. `IHalLinkBuilder.Template("orders:search")` called
+2. `HalLinkBuilder` retrieves the route URI pattern for `"orders:search"` (e.g., `/orders/{query}`)
+3. Returns `LinkObject { Href = "/orders/{query}", Templated = true }`
+4. Caller includes the link in the `Resource` as an RFC 6570 URI template
+
+### Scenario: Content negotiation with raw Resource return
+
+1. `AddHal` registered on `IMvcBuilder`
+2. Controller action returns a raw `Resource` (not wrapped in `HalResult`)
+3. Request includes `Accept: application/hal+json`
+4. Patched `SystemTextJsonOutputFormatter` matches the media type
+5. Response is `200 OK` with `Content-Type: application/hal+json` and HAL-serialized body
+
+### Scenario: Idempotent registration
+
+1. Application startup calls `services.AddHal(...)` twice
+2. `HalRegistrationMarker` sentinel detected on second call
+3. Second call returns immediately without registering duplicate services
+4. DI container contains each service exactly once; no error is thrown
+
+---
+
+## Out of Scope (v1)
+
+The following capabilities are explicitly deferred and must not be implemented in the initial version:
+
+- **HAL-FORMS integration** -- form-based action templates are not interpreted or rendered
+- **CURIE expansion in link builder** -- CURIE rels are not expanded; callers use compact form
+- **Automatic pagination link injection** -- next/prev/first/last links are not auto-generated
+- **Response caching / ETag** -- no HTTP cache or ETag header handling
+- **HAL resources in error responses** -- problem responses contain no `_links` or `_embedded`
+- **TypedResults integration** -- `TypedResults.Ok<HalResult>` patterns are not supported
+- **XML HAL** -- only JSON serialization is supported
+- **OpenAPI / Swashbuckle annotation** -- no automatic OpenAPI schema generation for HAL types

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -97,6 +97,8 @@ var server = new HalMcpServer(httpClient, rootUri);
 
 ## IDEA-03: ASP.NET Core Integration (`Chatter.Rest.Hal.AspNetCore` package)
 
+**Status:** In Progress -- see docs/aspnetcore/
+
 **Value:** High — eliminates manual wiring for every server-side consumer
 **Difficulty:** Medium
 **Depends on:** Nothing


### PR DESCRIPTION
## Summary

- Adds `docs/aspnetcore/requirements.md` with REQ-01 through REQ-37 covering registration, `HalOptions`, `IHalLinkBuilder`, `HalResult`, `HalResults`, controller extensions, auto-self injection, Problem Details, and serialization
- Adds `docs/aspnetcore/architecture.md` with namespace map, pseudocode for all 12 public types and 7 internal types, registration sequence, serialization flow, auto-self injection flow, expression resolution algorithm, and full test strategy (unit + integration)
- Updates `docs/backlog.md` IDEA-03 status to In Progress
- Updates `CLAUDE.md` Documentation Index with links to both new docs

## Test plan

- [ ] Verify `docs/aspnetcore/requirements.md` contains REQ-01 through REQ-37 (no gaps)
- [ ] Verify `docs/aspnetcore/architecture.md` contains pseudocode for all public and internal types
- [ ] Verify `IOptions<HalOptions>` referenced in both docs (no static singleton pattern)
- [ ] Verify `CLAUDE.md` Documentation Index includes both new doc rows
- [ ] Verify `docs/backlog.md` IDEA-03 shows In Progress status

🤖 Generated with [Claude Code](https://claude.com/claude-code)