### PR TITLE
docs(client): fix 3 findings from post-merge review

### DIFF
--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -1258,6 +1258,7 @@ When a logger overload is called with a non-null logger, it logs rel resolution 
 - `FollowLinkAsAsync<TResult>` accepts a single explicit type param; `T` of the receiver is already known
 - `FollowLinksAsAsync<TResult>` yields `IAsyncEnumerable<Resource<TResult>?>`
 - `PostToAsAsync<TBody, TResult>`: both type arguments must be specified explicitly (C# does not allow partial type argument specification)
+- `PostToAsAsync<TResult>(rel, object body, ...)`: single explicit type param; delegates to `PostToAsync<object, TResult>` on `_inner`
 - `PostToAsAsync<TResult>(..., HttpContent, ...)` returns `Resource<TResult>?`
 - Untyped-return `Resource<T>` extension overloads delegate correctly to `.Inner` for all verbs
 

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -54,7 +54,7 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 **REQ-02:** `IHalClient` exposes async methods for all standard HTTP verbs: `GetAsync`, `PostAsync`, `PutAsync`, `PatchAsync`, and `DeleteAsync`. All methods accept a `Uri` parameter and a `CancellationToken` with a default value.
 
-**REQ-03:** `GetAsync` returns `Resource?` (untyped) or `Resource<T>?` (typed, where `Resource<T>` is a thin wrapper defined in this package that provides strongly-typed access to state via `State()`). Both overloads return `null` when the server responds with HTTP 404.
+**REQ-03:** `GetAsync` returns `Resource?` (untyped) or `Resource<T>?` (typed, where `Resource<T>` is a typed resource facade defined in this package that provides strongly-typed access to state via `State()` and exposes typed traversal and mutation methods). Both overloads return `null` when the server responds with HTTP 404.
 
 **REQ-04:** `PostAsync`, `PutAsync`, and `PatchAsync` each have four overloads:
 - (a) Non-generic, object body: accepts `object` (serialized as JSON), returns `Resource?`
@@ -107,7 +107,7 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 ### DI registration (requires `Chatter.Rest.Hal.Client.DependencyInjection`)
 
-**REQ-16:** `AddHalClient(Action<HalClientOptions>)` is an extension method on `IServiceCollection` (available in the `Chatter.Rest.Hal.Client.DependencyInjection` package) that registers `IHalClient` / `HalClient` as a service and manages the `HttpClient` internally.
+**REQ-16:** `AddHalClient(Action<HalClientOptions>)` is an extension method on `IServiceCollection` (available in the `Chatter.Rest.Hal.Client.DependencyInjection` package) that registers `IHalClient` (backed by `HalClient`) as a service and manages the `HttpClient` internally.
 
 **REQ-17:** `AddHalOptions(Action<HalClientOptions>)` is an extension method on `IHttpClientBuilder` (available in the `Chatter.Rest.Hal.Client.DependencyInjection` package) that composes `HalClient` with `IHttpClientFactory`, enabling Polly policies, auth `DelegatingHandler`s, and named/typed client lifecycle management. Options are registered as named options keyed by `builder.Name` using `IOptionsMonitor<HalClientOptions>.Get(builder.Name)` for resolution, ensuring that multiple `AddHalOptions` calls on different builders use fully independent options.
 


### PR DESCRIPTION
## Summary

Post-merge fixes for three low/medium findings surfaced after PR #73:

- **REQ-16 DI clarity** — Changed `IHalClient / HalClient` to `IHalClient (backed by HalClient)` to make clear only the interface is resolvable from DI, not the concrete type
- **Resource<T> description** — Updated "thin wrapper" to "typed resource facade" since the API now includes traversal and mutation instance methods
- **Missing test scenario** — Added explicit test scenario for `PostToAsAsync<TResult>(rel, object body, ...)` single-type-param overload that delegates to `PostToAsync<object, TResult>` on `_inner`

## Test plan

- [ ] Review 2-file diff — all changes are doc-only, no source code
- [ ] Confirm REQ-16 wording matches typed-client registration behavior documented in architecture.md
- [ ] Confirm `Resource<T>` description matches the full API surface in architecture.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)