### PR TITLE
docs(client): fix 5 security-review findings in HAL client design docs

### DIFF
--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -132,7 +132,10 @@ public sealed class Resource<T> where T : class
     /// Delegates to <c>Resource.State&lt;T&gt;(JsonSerializerOptions?)</c>, which
     /// accepts options directly. No internal accessor or re-serialization is needed.
     /// </summary>
-    public T? State() => _inner.State<T>(_jsonOptions);
+    /// When _jsonOptions is null, delegates to parameterless State<T>() on inner
+    /// Resource (uses resource's own captured JsonSerializerOptions from deserialization).
+    /// When non-null, passes options explicitly.
+    public T? State() => _jsonOptions is null ? _inner.State<T>() : _inner.State<T>(_jsonOptions);
 
     // ── Typed traversal (single explicit type param; T of receiver is already known) ──
 
@@ -437,14 +440,20 @@ public sealed class HalClient : IHalClient
 
 **Fields stored:**
 - `_httpClient` -- the underlying `HttpClient`
-- `_options` -- resolved `HalClientOptions`
+- `_expectedMediaType` -- `string`, copied from `options.ExpectedMediaType`
+- `_strictContentType` -- `bool`, copied from `options.StrictContentType`
+- `_jsonOptions` -- `JsonSerializerOptions?`, copied from `options.JsonOptions`
 - `_logger` -- the logger. When `null`, `NullLogger<HalClient>.Instance` is used.
-- `_acceptHeader` -- parsed `MediaTypeWithQualityHeaderValue` from `_options.AcceptMediaType`; computed once in the constructor.
+- `_acceptHeader` -- parsed `MediaTypeWithQualityHeaderValue` from `options.AcceptMediaType`; computed once in the constructor.
 
 **Constructor behavior:**
-- Stores `httpClient`, `options`, and `logger ?? NullLogger<HalClient>.Instance`.
+- Copies all relevant fields from options into private readonly fields; no live reference to the passed-in `HalClientOptions` is retained.
+- Stores `httpClient` and `logger ?? NullLogger<HalClient>.Instance`.
 - Validates `options.AcceptMediaType`: throws `ArgumentException` if the value is null or empty. Message: `"HalClientOptions.AcceptMediaType must not be null or empty."`. Then calls `MediaTypeWithQualityHeaderValue.Parse(options.AcceptMediaType)` and stores the result as `_acceptHeader`; a malformed value causes `FormatException` to propagate from `Parse()`.
 - Validates `options.ExpectedMediaType`: throws `ArgumentException` if the value is null, empty, or contains a `';'` character. Message: `"HalClientOptions.ExpectedMediaType must be a bare media type without parameters (e.g., \"application/hal+json\")."`.
+- Snapshots `_expectedMediaType = options.ExpectedMediaType`, `_strictContentType = options.StrictContentType`, and `_jsonOptions = options.JsonOptions`.
+
+> **Rationale:** `HalClientOptions` is a mutable POCO. Snapshotting prevents post-construction mutation from altering client behavior.
 
 > **Note:** The DI companion package resolves `IOptions<HalClientOptions>.Value` before constructing `HalClient`, so the base package has no dependency on `Microsoft.Extensions.Options`.
 
@@ -517,19 +526,19 @@ SendAsync(HttpMethod method, Uri uri, HttpContent? content, CancellationToken ct
         return null
 
     // 5. Validate Content-Type
-    // HAL media type: compare MediaType (no parameters) case-insensitively to _options.ExpectedMediaType
+    // HAL media type: compare MediaType (no parameters) case-insensitively to _expectedMediaType
     // Null ContentType header is treated as non-HAL
     responseContentType = response.Content.Headers.ContentType?.MediaType
     isHal = responseContentType is not null &&
-            string.Equals(responseContentType, _options.ExpectedMediaType, StringComparison.OrdinalIgnoreCase)
+            string.Equals(responseContentType, _expectedMediaType, StringComparison.OrdinalIgnoreCase)
     if not isHal:
-        if _options.StrictContentType:
+        if _strictContentType:
             throw new HalResponseException(uri, responseContentType)
         return null
 
     // 6. Deserialize
     stream = await response.Content.ReadAsStreamAsync(ct)
-    jsonOptions = _options.JsonOptions ?? defaultHalJsonOptions
+    jsonOptions = _jsonOptions ?? defaultHalJsonOptions
     return await JsonSerializer.DeserializeAsync<Resource>(stream, jsonOptions, ct)
 ```
 
@@ -547,9 +556,9 @@ SendAsync(HttpMethod method, Uri uri, HttpContent? content, CancellationToken ct
 - **`PatchAsync<T>`:** Same pattern with `HttpMethod.Patch`; wraps deserialized `Resource` in `new Resource<T>(resource, jsonOptions)`.
 - **`DeleteAsync`:** `method = HttpMethod.Delete`, no content, no response deserialization. Calls `EnsureSuccessStatusCode()` and returns. Returns normally on 404.
 
-Where `jsonOptions` is `_options.JsonOptions ?? defaultHalJsonOptions` (already resolved earlier in `SendAsync`).
+Where `jsonOptions` is `_jsonOptions ?? defaultHalJsonOptions` (already resolved earlier in `SendAsync`).
 
-**Object body serialization:** When a method accepts `object body`, the body is serialized via `JsonSerializer.Serialize(body, _options.JsonOptions ?? defaultHalJsonOptions)` and wrapped in `StringContent` with media type `"application/json"` and `UTF-8` encoding.
+**Object body serialization:** When a method accepts `object body`, the body is serialized via `JsonSerializer.Serialize(body, _jsonOptions ?? defaultHalJsonOptions)` and wrapped in `StringContent` with media type `"application/json"` and `UTF-8` encoding.
 
 > **`HttpContent` ownership:** When a caller passes raw `HttpContent` to a method overload (e.g., `PostAsync(Uri, HttpContent, CT)`), `HalClient` attaches it to the `HttpRequestMessage`. Disposing the `HttpRequestMessage` (via `using var`) also disposes the attached content. **Callers must not reuse `HttpContent` instances after passing them to `HalClient`.** Callers who need to send the same content to multiple endpoints must create a new `HttpContent` for each call.
 
@@ -752,8 +761,9 @@ public static Task<Resource<T>?> FollowLinkAsync<T>(
 **Non-templated flow:**
 1. Call `ResolveLink(resource, rel)` to get the `Link`
 2. Extract `linkObject = link.LinkObjects[0]`
-3. Construct `Uri` from `linkObject.Href` via `new Uri(linkObject.Href, UriKind.RelativeOrAbsolute)`
-4. Call `client.GetAsync(uri, ct)` or `client.GetAsync<T>(uri, ct)`
+3. If `linkObject.Templated == true`, throw `InvalidOperationException`: `"Link relation '{rel}' is templated; use the overload that accepts variables."` This check occurs before any HTTP call.
+4. Construct `Uri` from `linkObject.Href` via `new Uri(linkObject.Href, UriKind.RelativeOrAbsolute)`
+5. Call `client.GetAsync(uri, ct)` or `client.GetAsync<T>(uri, ct)`
 
 > **Relative URI handling:** `Uri(href, UriKind.RelativeOrAbsolute)` accepts both absolute and relative URIs. Relative URIs (e.g., `/orders/42`) are resolved against `HttpClient.BaseAddress` by the underlying `HttpClient`. If `BaseAddress` is null and the URI is relative, `HttpClient.SendAsync` throws `InvalidOperationException`. Callers navigating HAL APIs with relative links must configure `BaseAddress` on the `HttpClient`.
 
@@ -774,7 +784,7 @@ public static IAsyncEnumerable<Resource?> FollowLinksAsync(
     this Resource resource,
     string rel,
     IHalClient client,
-    CancellationToken ct = default);
+    [EnumeratorCancellation] CancellationToken ct = default);
 
 // With logger
 public static IAsyncEnumerable<Resource?> FollowLinksAsync(
@@ -782,14 +792,14 @@ public static IAsyncEnumerable<Resource?> FollowLinksAsync(
     string rel,
     IHalClient client,
     ILogger logger,
-    CancellationToken ct = default);
+    [EnumeratorCancellation] CancellationToken ct = default);
 
 // Typed — no logger
 public static IAsyncEnumerable<Resource<T>?> FollowLinksAsync<T>(
     this Resource resource,
     string rel,
     IHalClient client,
-    CancellationToken ct = default) where T : class;
+    [EnumeratorCancellation] CancellationToken ct = default) where T : class;
 
 // Typed — with logger
 public static IAsyncEnumerable<Resource<T>?> FollowLinksAsync<T>(
@@ -797,19 +807,24 @@ public static IAsyncEnumerable<Resource<T>?> FollowLinksAsync<T>(
     string rel,
     IHalClient client,
     ILogger logger,
-    CancellationToken ct = default) where T : class;
+    [EnumeratorCancellation] CancellationToken ct = default) where T : class;
 ```
+
+> `[EnumeratorCancellation]` ensures `.WithCancellation(ct)` on the returned `IAsyncEnumerable` propagates the token to the iterator's `ct` parameter. Without this attribute, compiler warning CS8425 is emitted and `WithCancellation` tokens are silently ignored.
+
+> **Test note:** Tests must verify `.WithCancellation(token)` propagates cancellation -- i.e., passing a pre-cancelled token via `WithCancellation` causes the iterator to throw `OperationCanceledException`.
 
 **Flow:**
 1. Call `ResolveLink(resource, rel)` to get the `Link`
-2. Launch all fetches concurrently:
+2. For each `LinkObject` in `link.LinkObjects`, if `lo.Templated == true`, throw `InvalidOperationException`: `"Link relation '{rel}' contains a templated link; use FollowLinkAsync with variables for templated rels."` This check occurs before any HTTP call -- the entire batch is rejected if any entry is templated.
+3. Launch all fetches concurrently:
    ```
    tasks = link.LinkObjects
        .Select(lo => client.GetAsync(new Uri(lo.Href, UriKind.RelativeOrAbsolute), ct))
        .ToArray()
    ```
-3. Await all: `results = await Task.WhenAll(tasks)`
-4. Yield results sequentially:
+4. Await all: `results = await Task.WhenAll(tasks)`
+5. Yield results sequentially:
    ```
    foreach (var result in results)
        yield return result
@@ -817,7 +832,9 @@ public static IAsyncEnumerable<Resource<T>?> FollowLinksAsync<T>(
 
 All links are fetched concurrently via `Task.WhenAll`. Results are buffered and then yielded sequentially. The caller still consumes results via `await foreach` over `IAsyncEnumerable<Resource?>`.
 
-**Typed flow (`FollowLinksAsync<T>`):** Identical to the untyped flow except step 2 calls `client.GetAsync<T>(new Uri(lo.Href, UriKind.RelativeOrAbsolute), ct)` for each link object, producing `Task<Resource<T>?>[]` results.
+**Typed flow (`FollowLinksAsync<T>`):** Identical to the untyped flow except step 3 calls `client.GetAsync<T>(new Uri(lo.Href, UriKind.RelativeOrAbsolute), ct)` for each link object, producing `Task<Resource<T>?>[]` results.
+
+> **Test coverage:** Tests must cover: non-templated overload throws `InvalidOperationException` when `Templated==true`; templated overload works normally for `Templated==true` links; non-templated overload works normally for `Templated==false` links.
 
 ---
 
@@ -900,8 +917,9 @@ public static Task<Resource<TResponse>?> PostToAsync<TResponse>(
 **Flow (all mutation methods):**
 1. Call `ResolveLink(resource, rel)` to get the `Link`
 2. Extract `linkObject = link.LinkObjects[0]`
-3. Construct `Uri` from `linkObject.Href` via `new Uri(linkObject.Href, UriKind.RelativeOrAbsolute)`
-4. Call the appropriate `client.PostAsync` / `client.PutAsync` / `client.PatchAsync` overload (typed overload calls `client.PostAsync<TResponse>` / `client.PutAsync<TResponse>` / `client.PatchAsync<TResponse>` for the typed extension method; the typed `HttpContent` overload calls `client.PostAsync<TResponse>(uri, content, ct)` and returns the result directly)
+3. If `linkObject.Templated == true`, throw `InvalidOperationException`: `"Link relation '{rel}' is templated; use URI template expansion before calling mutation methods."` This check occurs before any HTTP call.
+4. Construct `Uri` from `linkObject.Href` via `new Uri(linkObject.Href, UriKind.RelativeOrAbsolute)`
+5. Call the appropriate `client.PostAsync` / `client.PutAsync` / `client.PatchAsync` overload (typed overload calls `client.PostAsync<TResponse>` / `client.PutAsync<TResponse>` / `client.PatchAsync<TResponse>` for the typed extension method; the typed `HttpContent` overload calls `client.PostAsync<TResponse>(uri, content, ct)` and returns the result directly)
 
 ---
 
@@ -927,8 +945,9 @@ public static Task DeleteToAsync(
 **Flow:**
 1. Call `ResolveLink(resource, rel)` to get the `Link`
 2. Extract `linkObject = link.LinkObjects[0]`
-3. Construct `Uri` from `linkObject.Href` via `new Uri(linkObject.Href, UriKind.RelativeOrAbsolute)`
-4. Call `client.DeleteAsync(uri, ct)`
+3. If `linkObject.Templated == true`, throw `InvalidOperationException`: `"Link relation '{rel}' is templated; use URI template expansion before calling mutation methods."` This check occurs before any HTTP call.
+4. Construct `Uri` from `linkObject.Href` via `new Uri(linkObject.Href, UriKind.RelativeOrAbsolute)`
+5. Call `client.DeleteAsync(uri, ct)`
 
 Returns `Task`, not `Task<Resource?>`. No response body is deserialized.
 

--- a/docs/client/architecture.md
+++ b/docs/client/architecture.md
@@ -1258,6 +1258,7 @@ When a logger overload is called with a non-null logger, it logs rel resolution 
 - `FollowLinkAsAsync<TResult>` accepts a single explicit type param; `T` of the receiver is already known
 - `FollowLinksAsAsync<TResult>` yields `IAsyncEnumerable<Resource<TResult>?>`
 - `PostToAsAsync<TBody, TResult>`: both type arguments must be specified explicitly (C# does not allow partial type argument specification)
+- `PostToAsAsync<TResult>(rel, object body, ...)`: single explicit type param; delegates to `PostToAsync<object, TResult>` on `_inner`
 - `PostToAsAsync<TResult>(..., HttpContent, ...)` returns `Resource<TResult>?`
 - Untyped-return `Resource<T>` extension overloads delegate correctly to `.Inner` for all verbs
 

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -121,6 +121,8 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 **REQ-19a:** When resolving a rel, if the resource contains duplicate `Link` entries with the same rel, the resolution throws `InvalidOperationException`. This is consistent with `LinkCollectionExtensions.GetLinkOrDefault`, which uses `SingleOrDefault` internally. This check occurs before any HTTP request is made.
 
+**REQ-19b:** Non-templated traversal overloads (`FollowLinkAsync` without variables, `FollowLinksAsync`) must throw `InvalidOperationException` before any HTTP call when the selected `LinkObject` has `Templated == true`. The error message must identify the rel and instruct the caller to use the templated overload.
+
 **REQ-20:** `FollowLinkAsync<T>(string rel, IHalClient client)` performs the same resolution as REQ-19 but deserializes the response as `Resource<T>?`.
 
 **REQ-21:** `FollowLinkAsync(string rel, IHalClient client, object variables)` resolves a templated link by delegating to `LinkObject.Expand()` with the provided variables, then performs an HTTP GET. Returns `Resource?`. Throws `HalLinkNotFoundException` if the rel is absent. (The `object variables` parameter is converted to `IDictionary<string, string>` via an internal `ObjectToDictionary` helper that reflects public properties before calling `LinkObject.Expand()`.)
@@ -164,6 +166,8 @@ All overloads throw `HalLinkNotFoundException` if the rel is absent. `TBody` has
 - (b) `DeleteToAsync(string rel, IHalClient client, ILogger logger, CancellationToken ct = default)` — with explicit logger
 
 Both overloads return `Task` (no body deserialization). Both throw `HalLinkNotFoundException` if the rel is absent.
+
+**REQ-28a:** Non-templated mutation overloads (`PostToAsync`, `PutToAsync`, `PatchToAsync`, `DeleteToAsync`) must throw `InvalidOperationException` before any HTTP call when the resolved `LinkObject` has `Templated == true`.
 
 **REQ-29:** Raw `HttpClient` overloads exist for every `PostToAsync`, `PutToAsync`, `PatchToAsync`, and `DeleteToAsync` signature.
 
@@ -225,6 +229,7 @@ Both overloads return `Task` (no body deserialization). Both throw `HalLinkNotFo
 |---|---|
 | Rel not found on resource | Throw `HalLinkNotFoundException` (before any HTTP) |
 | Duplicate rels on resource | Throw `InvalidOperationException` (before any HTTP) |
+| Templated link with non-templated overload | Throw `InvalidOperationException` (before any HTTP) |
 | HTTP 2xx with body | Deserialize and return |
 | HTTP 204 or explicit `Content-Length: 0` | Return `null`; `DeleteAsync` completes normally (no body, no Content-Type check) |
 | HTTP 3xx | `HttpClient` follows redirects; non-redirect throws `HttpRequestException` |
@@ -361,7 +366,7 @@ These scenarios describe end-to-end behavior for test derivation.
 ### Scenario: Convenience extension on raw HttpClient
 
 1. Caller has an `HttpClient` but no `HalClient`
-2. Caller calls `httpClient.GetHalAsync(new Uri("/orders"))`
+2. Caller calls `httpClient.GetHalAsync(new Uri("/orders", UriKind.Relative))`
 3. Extension sends `GET /orders` with `Accept: application/hal+json`
 4. Server responds with `200 OK` and a HAL resource
 5. Method returns the deserialized `Resource`

--- a/docs/client/requirements.md
+++ b/docs/client/requirements.md
@@ -54,7 +54,7 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 **REQ-02:** `IHalClient` exposes async methods for all standard HTTP verbs: `GetAsync`, `PostAsync`, `PutAsync`, `PatchAsync`, and `DeleteAsync`. All methods accept a `Uri` parameter and a `CancellationToken` with a default value.
 
-**REQ-03:** `GetAsync` returns `Resource?` (untyped) or `Resource<T>?` (typed, where `Resource<T>` is a thin wrapper defined in this package that provides strongly-typed access to state via `State()`). Both overloads return `null` when the server responds with HTTP 404.
+**REQ-03:** `GetAsync` returns `Resource?` (untyped) or `Resource<T>?` (typed, where `Resource<T>` is a typed resource facade defined in this package that provides strongly-typed access to state via `State()` and exposes typed traversal and mutation methods). Both overloads return `null` when the server responds with HTTP 404.
 
 **REQ-04:** `PostAsync`, `PutAsync`, and `PatchAsync` each have four overloads:
 - (a) Non-generic, object body: accepts `object` (serialized as JSON), returns `Resource?`
@@ -107,7 +107,7 @@ Already uses `Chatter.Rest.Hal` for building HAL documents server-side. Wants to
 
 ### DI registration (requires `Chatter.Rest.Hal.Client.DependencyInjection`)
 
-**REQ-16:** `AddHalClient(Action<HalClientOptions>)` is an extension method on `IServiceCollection` (available in the `Chatter.Rest.Hal.Client.DependencyInjection` package) that registers `IHalClient` / `HalClient` as a service and manages the `HttpClient` internally.
+**REQ-16:** `AddHalClient(Action<HalClientOptions>)` is an extension method on `IServiceCollection` (available in the `Chatter.Rest.Hal.Client.DependencyInjection` package) that registers `IHalClient` (backed by `HalClient`) as a service and manages the `HttpClient` internally.
 
 **REQ-17:** `AddHalOptions(Action<HalClientOptions>)` is an extension method on `IHttpClientBuilder` (available in the `Chatter.Rest.Hal.Client.DependencyInjection` package) that composes `HalClient` with `IHttpClientFactory`, enabling Polly policies, auth `DelegatingHandler`s, and named/typed client lifecycle management. Options are registered as named options keyed by `builder.Name` using `IOptionsMonitor<HalClientOptions>.Get(builder.Name)` for resolution, ensuring that multiple `AddHalOptions` calls on different builders use fully independent options.
 


### PR DESCRIPTION
## Summary

- **Finding 1 (Medium)**: Snapshot `HalClientOptions` fields into private readonly fields in `HalClient` constructor; no live reference to mutable options object retained
- **Finding 2 (Medium)**: Non-templated traversal/mutation overloads (`FollowLinkAsync`, `FollowLinksAsync`, `PostToAsync`, `PutToAsync`, `PatchToAsync`, `DeleteToAsync`) now documented to throw `InvalidOperationException` before any HTTP call when `LinkObject.Templated == true`; added REQ-19b and REQ-28a
- **Finding 3 (Medium)**: `Resource<T>.State()` now uses `_jsonOptions is null ? _inner.State<T>() : _inner.State<T>(_jsonOptions)` so null propagates to inner resource's own captured options
- **Finding 4 (Low)**: `[EnumeratorCancellation]` added to all `FollowLinksAsync` cancellation parameters; test coverage note added for `.WithCancellation(ct)` propagation
- **Finding 5 (Low)**: Fixed invalid `new Uri("/orders")` example to `new Uri("/orders", UriKind.Relative)`

## Test plan

- [ ] Verify no `_options.` references remain in architecture.md
- [ ] Verify all 4 FollowLinksAsync signatures carry `[EnumeratorCancellation]`
- [ ] Verify Templated==true guards present in all 6 non-templated overload flows
- [ ] Verify REQ-19b and REQ-28a exist in requirements.md
- [ ] Verify Error Handling Summary table has Templated row
- [ ] Verify `Resource<T>.State()` pseudocode uses null-conditional pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)