### PR TITLE
chore: bump Chatter.Rest.Hal version to 1.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ See [docs/development.md](docs/development.md) for CI/CD workflow details.
 
 ## Package Versions
 
-- `Chatter.Rest.Hal` — v1.0.1
+- `Chatter.Rest.Hal` — v1.1.0
 - `Chatter.Rest.Hal.CodeGenerators` — v0.3.0
 
 External dependency: `Chatter.Rest.UriTemplates` v0.1.0 ([NuGet](https://www.nuget.org/packages/Chatter.Rest.UriTemplates/))

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -402,7 +402,7 @@ Chatter.Rest.Hal.sln
 │   ├── Chatter.Rest.Hal/            # Core library
 │   │   ├── depends on: System.Text.Json (inbox on net8.0, NuGet on netstandard2.0)
 │   │   ├── depends on: Chatter.Rest.UriTemplates (external NuGet package)
-│   │   └── NuGet: Chatter.Rest.Hal v1.0.1
+│   │   └── NuGet: Chatter.Rest.Hal v1.1.0
 │   │
 │   ├── Chatter.Rest.Hal.Core/       # Shared attribute
 │   │   ├── contains: HalResponseAttribute only

--- a/src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
+++ b/src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
     <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A dotnet/c# implementation of the Hypertext Application Language (HAL+json) specification for RESTful Web Apis</Description>


### PR DESCRIPTION
## Summary
- Bumps `Chatter.Rest.Hal` package version from 1.0.1 to 1.1.0 in csproj, CLAUDE.md, and docs/architecture.md
- No other package versions changed (CodeGenerators v0.3.0, UriTemplates v0.1.0 remain as-is)

## Test plan
- [x] Grep confirms zero remaining `1.0.1` occurrences in the three changed files
- [x] CodeGenerators and UriTemplates versions verified unchanged
- [x] Only three files modified; no other changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)