### PR TITLE
chore: incorporate SemVer versioning into agent workflow

### DIFF
--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -187,7 +187,7 @@ Files:
 - src/[package]/[package].csproj — <Version>A.B.C</Version>
 - CLAUDE.md — Package Versions table row
 - docs/architecture.md — solution structure table row
-- CHANGELOG.md (or CHANGELOG-CodeGenerators.md) — add ## [A.B.C] - YYYY-MM-DD section above [Unreleased], update comparison link
+- [package-changelog-file] — add ## [A.B.C] - YYYY-MM-DD section above [Unreleased], update comparison link
 
 Done when: All four files updated, version consistent across all.
 Git: [same class as parent branch], no new commit (orchestrator checkpoints)

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -107,10 +107,20 @@ Do not proceed when required git context is missing.
    - confirm git workflow remained compliant
    - inspect key outputs for coherence
    - decide whether a checkpoint commit is warranted
-10. After all phases:
+10. Version bump check (after phases complete, before PR readiness):
+   - Determine if any non-markdown files under a packable package's `src/` directory were changed
+   - If yes:
+     - Determine bump type (major/minor/patch) from commit types and API impact
+     - If ambiguous, ask user to confirm bump type before proceeding
+     - Delegate version file edits to coder: `.csproj`, `CLAUDE.md`, `docs/architecture.md`, relevant CHANGELOG
+     - Wait for coder to complete, then verify all four files updated atomically
+     - Checkpoint commit the version bump
+   - If no (docs/tests/CI/governance only): skip version bump
+11. After all phases:
    - verify final coherence
    - confirm validation was performed
    - confirm PR readiness under the workflow
+   - version bump included if non-markdown src/ files changed (CI version-check will enforce)
    - open PR if the approved plan is complete
 
 ## Delegation Template
@@ -168,6 +178,21 @@ Constraints:
 ```
 
 Describe what must be true, not how to implement it, unless a constraint is already fixed by the user, planner, prior phases, or approved design.
+
+### Version bump delegation (compact form)
+
+```text
+Task: Bump [package] version from X.Y.Z to A.B.C
+Files:
+- src/[package]/[package].csproj — <Version>A.B.C</Version>
+- CLAUDE.md — Package Versions table row
+- docs/architecture.md — solution structure table row
+- CHANGELOG.md (or CHANGELOG-CodeGenerators.md) — add ## [A.B.C] - YYYY-MM-DD section above [Unreleased], update comparison link
+
+Done when: All four files updated, version consistent across all.
+Git: [same class as parent branch], no new commit (orchestrator checkpoints)
+Constraints: Do not modify other files. Today's date: [current date].
+```
 
 ## Phase Verification
 After each phase, verify:

--- a/.github/workflows/codegen-cicd.yml
+++ b/.github/workflows/codegen-cicd.yml
@@ -113,21 +113,41 @@ jobs:
 
           VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
 
-          LATEST_TAG=$(git tag -l 'codegen/v*' | sort -V | tail -1)
+          # Filter out pre-release tags to get latest stable release baseline
+          LATEST_TAG=$(git tag -l 'codegen/v*' | grep -v -- '-' | sort -V | tail -1)
 
           if [ -z "$LATEST_TAG" ]; then
-            echo "No existing codegen/v* tags found. Bootstrapping — version check passes."
+            echo "No existing codegen/v* release tags found. Bootstrapping — version check passes."
             exit 0
           fi
 
           TAG_VERSION="${LATEST_TAG#codegen/v}"
 
-          if [ "$VERSION" = "$TAG_VERSION" ]; then
-            echo "ERROR: csproj version ($VERSION) equals latest tag ($LATEST_TAG). Bump the version before merging."
+          # SemVer-aware strictly-greater comparison (strips pre-release suffix before comparing)
+          version_gt() {
+            local v1 v2
+            v1=$(echo "$1" | sed 's/-.*//')
+            v2=$(echo "$2" | sed 's/-.*//')
+            local IFS=.
+            local i
+            local parts1=($v1) parts2=($v2)
+            local len=${#parts2[@]}
+            [ ${#parts1[@]} -gt "$len" ] && len=${#parts1[@]}
+            for ((i=0; i<len; i++)); do
+              local p1=${parts1[i]:-0}
+              local p2=${parts2[i]:-0}
+              if ((10#$p1 > 10#$p2)); then return 0; fi
+              if ((10#$p1 < 10#$p2)); then return 1; fi
+            done
+            return 1
+          }
+
+          if ! version_gt "$VERSION" "$TAG_VERSION"; then
+            echo "ERROR: Version $VERSION must be greater than latest release tag version $TAG_VERSION. Bump the version before merging."
             exit 1
           fi
 
-          echo "Version check passed: csproj=$VERSION, latest tag=$LATEST_TAG"
+          echo "Version check passed: csproj=$VERSION, latest release tag=$LATEST_TAG"
 
   deploy:
     name: deploy

--- a/.github/workflows/codegen-cicd.yml
+++ b/.github/workflows/codegen-cicd.yml
@@ -92,62 +92,12 @@ jobs:
 
   version-check:
     name: version-check
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/version-check.yml
     if: github.event_name == 'pull_request'
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Check version bump
-        shell: bash
-        run: |
-          CHANGED=$(git diff --name-only "origin/main...HEAD" -- 'src/Chatter.Rest.Hal.CodeGenerators/' | grep -v '\.md$' || true)
-          if [ -z "$CHANGED" ]; then
-            echo "No non-markdown src/ changes detected. Version bump not required."
-            exit 0
-          fi
-          echo "Changed src/ files requiring version bump check:"
-          echo "$CHANGED"
-
-          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
-
-          # Filter out pre-release tags to get latest stable release baseline
-          LATEST_TAG=$(git tag -l 'codegen/v*' | grep -v -- '-' | sort -V | tail -1)
-
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No existing codegen/v* release tags found. Bootstrapping — version check passes."
-            exit 0
-          fi
-
-          TAG_VERSION="${LATEST_TAG#codegen/v}"
-
-          # SemVer-aware strictly-greater comparison (strips pre-release suffix before comparing)
-          version_gt() {
-            local v1 v2
-            v1=$(echo "$1" | sed 's/-.*//')
-            v2=$(echo "$2" | sed 's/-.*//')
-            local IFS=.
-            local i
-            local parts1=($v1) parts2=($v2)
-            local len=${#parts2[@]}
-            [ ${#parts1[@]} -gt "$len" ] && len=${#parts1[@]}
-            for ((i=0; i<len; i++)); do
-              local p1=${parts1[i]:-0}
-              local p2=${parts2[i]:-0}
-              if ((10#$p1 > 10#$p2)); then return 0; fi
-              if ((10#$p1 < 10#$p2)); then return 1; fi
-            done
-            return 1
-          }
-
-          if ! version_gt "$VERSION" "$TAG_VERSION"; then
-            echo "ERROR: Version $VERSION must be greater than latest release tag version $TAG_VERSION. Bump the version before merging."
-            exit 1
-          fi
-
-          echo "Version check passed: csproj=$VERSION, latest release tag=$LATEST_TAG"
+    with:
+      src-path: 'src/Chatter.Rest.Hal.CodeGenerators/'
+      csproj-path: 'src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj'
+      tag-prefix: 'codegen'
 
   deploy:
     name: deploy
@@ -182,30 +132,12 @@ jobs:
 
   tag:
     name: tag
+    uses: ./.github/workflows/create-version-tag.yml
     needs: deploy
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
     permissions:
       contents: write
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Create version tag
-        shell: bash
-        run: |
-          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
-          TAG="codegen/v${VERSION}"
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists. Skipping."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag -a "$TAG" -m "Chatter.Rest.Hal.CodeGenerators v${VERSION}"
-            git push origin "$TAG"
-            echo "Created and pushed tag $TAG"
-          fi
+    with:
+      csproj-path: 'src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj'
+      tag-prefix: 'codegen'
+      package-name: 'Chatter.Rest.Hal.CodeGenerators'

--- a/.github/workflows/codegen-cicd.yml
+++ b/.github/workflows/codegen-cicd.yml
@@ -11,6 +11,13 @@ on:
   push:
     branches:
       - 'feature/**'
+      - 'bugfix/**'
+      - 'hotfix/**'
+      - 'refactor/**'
+      - 'chore/**'
+      - 'docs/**'
+      - 'test/**'
+      - 'ci/**'
       - main
     paths:
       - '.github/workflows/codegen-cicd.yml'
@@ -83,6 +90,45 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
+  version-check:
+    name: version-check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        shell: bash
+        run: |
+          CHANGED=$(git diff --name-only "origin/main...HEAD" -- 'src/Chatter.Rest.Hal.CodeGenerators/' | grep -v '\.md$' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No non-markdown src/ changes detected. Version bump not required."
+            exit 0
+          fi
+          echo "Changed src/ files requiring version bump check:"
+          echo "$CHANGED"
+
+          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+
+          LATEST_TAG=$(git tag -l 'codegen/v*' | sort -V | tail -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No existing codegen/v* tags found. Bootstrapping — version check passes."
+            exit 0
+          fi
+
+          TAG_VERSION="${LATEST_TAG#codegen/v}"
+
+          if [ "$VERSION" = "$TAG_VERSION" ]; then
+            echo "ERROR: csproj version ($VERSION) equals latest tag ($LATEST_TAG). Bump the version before merging."
+            exit 1
+          fi
+
+          echo "Version check passed: csproj=$VERSION, latest tag=$LATEST_TAG"
+
   deploy:
     name: deploy
     needs: build
@@ -113,3 +159,33 @@ jobs:
             -k "${{ env.NUGET_AUTH_TOKEN }}" \
             -s "${{ env.NUGET_URL }}" \
             --skip-duplicate
+
+  tag:
+    name: tag
+    needs: deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create version tag
+        shell: bash
+        run: |
+          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+          TAG="codegen/v${VERSION}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Chatter.Rest.Hal.CodeGenerators v${VERSION}"
+            git push origin "$TAG"
+            echo "Created and pushed tag $TAG"
+          fi

--- a/.github/workflows/create-version-tag.yml
+++ b/.github/workflows/create-version-tag.yml
@@ -1,0 +1,45 @@
+name: Create Version Tag
+
+on:
+  workflow_call:
+    inputs:
+      csproj-path:
+        description: 'Path to the .csproj file containing <Version>'
+        required: true
+        type: string
+      tag-prefix:
+        description: 'Git tag prefix for this package (e.g., hal, codegen)'
+        required: true
+        type: string
+      package-name:
+        description: 'Human-readable package name for tag annotation (e.g., Chatter.Rest.Hal)'
+        required: true
+        type: string
+
+jobs:
+  tag:
+    name: tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create version tag
+        shell: bash
+        run: |
+          VERSION=$(grep -m1 '<Version>' '${{ inputs.csproj-path }}' | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+          TAG="${{ inputs.tag-prefix }}/v${VERSION}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "${{ inputs.package-name }} v${VERSION}"
+            git push origin "$TAG"
+            echo "Created and pushed tag $TAG"
+          fi

--- a/.github/workflows/hal-cicd.yml
+++ b/.github/workflows/hal-cicd.yml
@@ -99,21 +99,41 @@ jobs:
 
           VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
 
-          LATEST_TAG=$(git tag -l 'hal/v*' | sort -V | tail -1)
+          # Filter out pre-release tags to get latest stable release baseline
+          LATEST_TAG=$(git tag -l 'hal/v*' | grep -v -- '-' | sort -V | tail -1)
 
           if [ -z "$LATEST_TAG" ]; then
-            echo "No existing hal/v* tags found. Bootstrapping — version check passes."
+            echo "No existing hal/v* release tags found. Bootstrapping — version check passes."
             exit 0
           fi
 
           TAG_VERSION="${LATEST_TAG#hal/v}"
 
-          if [ "$VERSION" = "$TAG_VERSION" ]; then
-            echo "ERROR: csproj version ($VERSION) equals latest tag ($LATEST_TAG). Bump the version before merging."
+          # SemVer-aware strictly-greater comparison (strips pre-release suffix before comparing)
+          version_gt() {
+            local v1 v2
+            v1=$(echo "$1" | sed 's/-.*//')
+            v2=$(echo "$2" | sed 's/-.*//')
+            local IFS=.
+            local i
+            local parts1=($v1) parts2=($v2)
+            local len=${#parts2[@]}
+            [ ${#parts1[@]} -gt "$len" ] && len=${#parts1[@]}
+            for ((i=0; i<len; i++)); do
+              local p1=${parts1[i]:-0}
+              local p2=${parts2[i]:-0}
+              if ((10#$p1 > 10#$p2)); then return 0; fi
+              if ((10#$p1 < 10#$p2)); then return 1; fi
+            done
+            return 1
+          }
+
+          if ! version_gt "$VERSION" "$TAG_VERSION"; then
+            echo "ERROR: Version $VERSION must be greater than latest release tag version $TAG_VERSION. Bump the version before merging."
             exit 1
           fi
 
-          echo "Version check passed: csproj=$VERSION, latest tag=$LATEST_TAG"
+          echo "Version check passed: csproj=$VERSION, latest release tag=$LATEST_TAG"
 
   deploy:
     name: deploy

--- a/.github/workflows/hal-cicd.yml
+++ b/.github/workflows/hal-cicd.yml
@@ -78,62 +78,12 @@ jobs:
 
   version-check:
     name: version-check
-    runs-on: ubuntu-latest
+    uses: ./.github/workflows/version-check.yml
     if: github.event_name == 'pull_request'
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Check version bump
-        shell: bash
-        run: |
-          CHANGED=$(git diff --name-only "origin/main...HEAD" -- 'src/Chatter.Rest.Hal/' | grep -v '\.md$' || true)
-          if [ -z "$CHANGED" ]; then
-            echo "No non-markdown src/ changes detected. Version bump not required."
-            exit 0
-          fi
-          echo "Changed src/ files requiring version bump check:"
-          echo "$CHANGED"
-
-          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
-
-          # Filter out pre-release tags to get latest stable release baseline
-          LATEST_TAG=$(git tag -l 'hal/v*' | grep -v -- '-' | sort -V | tail -1)
-
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No existing hal/v* release tags found. Bootstrapping — version check passes."
-            exit 0
-          fi
-
-          TAG_VERSION="${LATEST_TAG#hal/v}"
-
-          # SemVer-aware strictly-greater comparison (strips pre-release suffix before comparing)
-          version_gt() {
-            local v1 v2
-            v1=$(echo "$1" | sed 's/-.*//')
-            v2=$(echo "$2" | sed 's/-.*//')
-            local IFS=.
-            local i
-            local parts1=($v1) parts2=($v2)
-            local len=${#parts2[@]}
-            [ ${#parts1[@]} -gt "$len" ] && len=${#parts1[@]}
-            for ((i=0; i<len; i++)); do
-              local p1=${parts1[i]:-0}
-              local p2=${parts2[i]:-0}
-              if ((10#$p1 > 10#$p2)); then return 0; fi
-              if ((10#$p1 < 10#$p2)); then return 1; fi
-            done
-            return 1
-          }
-
-          if ! version_gt "$VERSION" "$TAG_VERSION"; then
-            echo "ERROR: Version $VERSION must be greater than latest release tag version $TAG_VERSION. Bump the version before merging."
-            exit 1
-          fi
-
-          echo "Version check passed: csproj=$VERSION, latest release tag=$LATEST_TAG"
+    with:
+      src-path: 'src/Chatter.Rest.Hal/'
+      csproj-path: 'src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj'
+      tag-prefix: 'hal'
 
   deploy:
     name: deploy
@@ -168,30 +118,12 @@ jobs:
 
   tag:
     name: tag
+    uses: ./.github/workflows/create-version-tag.yml
     needs: deploy
-    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-
     permissions:
       contents: write
-
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-
-      - name: Create version tag
-        shell: bash
-        run: |
-          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
-          TAG="hal/v${VERSION}"
-
-          if git rev-parse "$TAG" >/dev/null 2>&1; then
-            echo "Tag $TAG already exists. Skipping."
-          else
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git tag -a "$TAG" -m "Chatter.Rest.Hal v${VERSION}"
-            git push origin "$TAG"
-            echo "Created and pushed tag $TAG"
-          fi
+    with:
+      csproj-path: 'src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj'
+      tag-prefix: 'hal'
+      package-name: 'Chatter.Rest.Hal'

--- a/.github/workflows/hal-cicd.yml
+++ b/.github/workflows/hal-cicd.yml
@@ -11,6 +11,13 @@ on:
   push:
     branches:
       - 'feature/**'
+      - 'bugfix/**'
+      - 'hotfix/**'
+      - 'refactor/**'
+      - 'chore/**'
+      - 'docs/**'
+      - 'test/**'
+      - 'ci/**'
       - main
     paths:
       - '**/src/Chatter.Rest.Hal/**'
@@ -69,6 +76,45 @@ jobs:
           retention-days: 5
           if-no-files-found: error
 
+  version-check:
+    name: version-check
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        shell: bash
+        run: |
+          CHANGED=$(git diff --name-only "origin/main...HEAD" -- 'src/Chatter.Rest.Hal/' | grep -v '\.md$' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No non-markdown src/ changes detected. Version bump not required."
+            exit 0
+          fi
+          echo "Changed src/ files requiring version bump check:"
+          echo "$CHANGED"
+
+          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+
+          LATEST_TAG=$(git tag -l 'hal/v*' | sort -V | tail -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No existing hal/v* tags found. Bootstrapping — version check passes."
+            exit 0
+          fi
+
+          TAG_VERSION="${LATEST_TAG#hal/v}"
+
+          if [ "$VERSION" = "$TAG_VERSION" ]; then
+            echo "ERROR: csproj version ($VERSION) equals latest tag ($LATEST_TAG). Bump the version before merging."
+            exit 1
+          fi
+
+          echo "Version check passed: csproj=$VERSION, latest tag=$LATEST_TAG"
+
   deploy:
     name: deploy
     needs: build
@@ -99,3 +145,33 @@ jobs:
             -k '${{ env.NUGET_AUTH_TOKEN }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
+
+  tag:
+    name: tag
+    needs: deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create version tag
+        shell: bash
+        run: |
+          VERSION=$(grep -m1 '<Version>' src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+          TAG="hal/v${VERSION}"
+
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists. Skipping."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag -a "$TAG" -m "Chatter.Rest.Hal v${VERSION}"
+            git push origin "$TAG"
+            echo "Created and pushed tag $TAG"
+          fi

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -40,7 +40,7 @@ jobs:
           VERSION=$(grep -m1 '<Version>' '${{ inputs.csproj-path }}' | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
 
           # Filter out pre-release tags to get latest stable release baseline
-          LATEST_TAG=$(git tag -l '${{ inputs.tag-prefix }}/v*' | grep -v -- '-' | sort -V | tail -1)
+          LATEST_TAG=$(git tag -l '${{ inputs.tag-prefix }}/v*' | grep -v -- '-' | sort -V | tail -1 || true)
 
           if [ -z "$LATEST_TAG" ]; then
             echo "No existing ${{ inputs.tag-prefix }}/v* release tags found. Bootstrapping — version check passes."

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,76 @@
+name: Version Check
+
+on:
+  workflow_call:
+    inputs:
+      src-path:
+        description: 'Source directory to check for non-markdown changes (e.g., src/MyPackage/)'
+        required: true
+        type: string
+      csproj-path:
+        description: 'Path to the .csproj file containing <Version>'
+        required: true
+        type: string
+      tag-prefix:
+        description: 'Git tag prefix for this package (e.g., hal, codegen)'
+        required: true
+        type: string
+
+jobs:
+  version-check:
+    name: version-check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check version bump
+        shell: bash
+        run: |
+          CHANGED=$(git diff --name-only "origin/main...HEAD" -- '${{ inputs.src-path }}' | grep -v '\.md$' || true)
+          if [ -z "$CHANGED" ]; then
+            echo "No non-markdown src/ changes detected. Version bump not required."
+            exit 0
+          fi
+          echo "Changed src/ files requiring version bump check:"
+          echo "$CHANGED"
+
+          VERSION=$(grep -m1 '<Version>' '${{ inputs.csproj-path }}' | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+
+          # Filter out pre-release tags to get latest stable release baseline
+          LATEST_TAG=$(git tag -l '${{ inputs.tag-prefix }}/v*' | grep -v -- '-' | sort -V | tail -1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No existing ${{ inputs.tag-prefix }}/v* release tags found. Bootstrapping — version check passes."
+            exit 0
+          fi
+
+          TAG_VERSION="${LATEST_TAG#${{ inputs.tag-prefix }}/v}"
+
+          # SemVer-aware strictly-greater comparison (strips pre-release suffix before comparing)
+          version_gt() {
+            local v1 v2
+            v1=$(echo "$1" | sed 's/-.*//')
+            v2=$(echo "$2" | sed 's/-.*//')
+            local IFS=.
+            local i
+            local parts1=($v1) parts2=($v2)
+            local len=${#parts2[@]}
+            [ ${#parts1[@]} -gt "$len" ] && len=${#parts1[@]}
+            for ((i=0; i<len; i++)); do
+              local p1=${parts1[i]:-0}
+              local p2=${parts2[i]:-0}
+              if ((10#$p1 > 10#$p2)); then return 0; fi
+              if ((10#$p1 < 10#$p2)); then return 1; fi
+            done
+            return 1
+          }
+
+          if ! version_gt "$VERSION" "$TAG_VERSION"; then
+            echo "ERROR: Version $VERSION must be greater than latest release tag version $TAG_VERSION. Bump the version before merging."
+            exit 1
+          fi
+
+          echo "Version check passed: csproj=$VERSION, latest release tag=$LATEST_TAG"

--- a/CHANGELOG-CodeGenerators.md
+++ b/CHANGELOG-CodeGenerators.md
@@ -1,0 +1,10 @@
+# Changelog — Chatter.Rest.Hal.CodeGenerators
+
+All notable changes to `Chatter.Rest.Hal.CodeGenerators` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/brenpike/Chatter.Rest.Hal/compare/codegen/v0.3.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog — Chatter.Rest.Hal
+
+All notable changes to `Chatter.Rest.Hal` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+[Unreleased]: https://github.com/brenpike/Chatter.Rest.Hal/compare/hal/v1.1.0...HEAD

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Chatter.Rest.Hal is a .NET/C# implementation of the HAL (Hypertext Application L
 | [docs/HAL_TEST_PLAN.md](docs/HAL_TEST_PLAN.md) | Spec-to-test mapping; consult when adding tests or evaluating spec compliance |
 | [docs/aspnetcore/requirements.md](docs/aspnetcore/requirements.md) | Package requirements (REQ-01–REQ-37) for `Chatter.Rest.Hal.AspNetCore` |
 | [docs/aspnetcore/architecture.md](docs/aspnetcore/architecture.md) | Architecture, type pseudocode, and test strategy for `Chatter.Rest.Hal.AspNetCore` |
+| [docs/versioning.md](docs/versioning.md) | SemVer rules, bump triggers, CHANGELOG convention, git tag policy |
 
 ## Solution Structure
 
@@ -91,6 +92,8 @@ See [docs/development.md](docs/development.md) for CI/CD workflow details.
 - `Chatter.Rest.Hal.CodeGenerators` — v0.3.0
 
 External dependency: `Chatter.Rest.UriTemplates` v0.1.0 ([NuGet](https://www.nuget.org/packages/Chatter.Rest.UriTemplates/))
+
+See [docs/versioning.md](docs/versioning.md) for full versioning policy, bump rules, and CHANGELOG convention.
 
 ## Memory Usage
 

--- a/agent-system-policy.md
+++ b/agent-system-policy.md
@@ -41,6 +41,8 @@ Owns presentational UI/UX work within assigned file scope.
 | Worktree decision | own | recommend only | no | no |
 | Checkpoint commit | own | no | delegated only | no |
 | PR submission | own | no | no | no |
+| Version bump type decision | own | no | no | no |
+| Version file edits | delegate | no | delegated only | no |
 
 ## Allowed Agent Set
 

--- a/docs/branching-pr-workflow.md
+++ b/docs/branching-pr-workflow.md
@@ -152,11 +152,7 @@ A version bump is **required** when a PR changes non-markdown files under a pack
 
 ### When a bump is required
 
-| Changed paths | Bump required for |
-|---|---|
-| `src/Chatter.Rest.Hal/**` (non-`.md`) | `Chatter.Rest.Hal` |
-| `src/Chatter.Rest.Hal.CodeGenerators/**` (non-`.md`) | `Chatter.Rest.Hal.CodeGenerators` |
-| `src/Chatter.Rest.Hal.Core/**` (non-`.md`) | Whichever dependent packages are affected |
+Non-markdown files under any packable package's `src/` directory trigger a bump for that package. Internal shared library changes may trigger bumps in dependent packages if public API is affected. Refer to `CLAUDE.md` for this project's package list and source paths.
 
 No bump required for: `docs/**`, `test/**`, `.github/workflows/**`, governance files, `*.md`.
 
@@ -179,7 +175,7 @@ Files updated atomically per bump (see [docs/versioning.md](versioning.md) for f
 - `.csproj` `<Version>` element (source of truth)
 - `CLAUDE.md` Package Versions table
 - `docs/architecture.md` solution structure table
-- `CHANGELOG.md` or `CHANGELOG-CodeGenerators.md`
+- Package CHANGELOG file (see `docs/development.md` for filename mapping)
 
 ### PR readiness gate
 

--- a/docs/branching-pr-workflow.md
+++ b/docs/branching-pr-workflow.md
@@ -146,6 +146,45 @@ Examples:
 - Stage only the files that belong to the completed phase or approved milestone.
 - Do not create checkpoint commits on `main`.
 
+## Version Bump Policy
+
+A version bump is **required** when a PR changes non-markdown files under a packable package's `src/` directory. See [docs/versioning.md](versioning.md) for the full policy.
+
+### When a bump is required
+
+| Changed paths | Bump required for |
+|---|---|
+| `src/Chatter.Rest.Hal/**` (non-`.md`) | `Chatter.Rest.Hal` |
+| `src/Chatter.Rest.Hal.CodeGenerators/**` (non-`.md`) | `Chatter.Rest.Hal.CodeGenerators` |
+| `src/Chatter.Rest.Hal.Core/**` (non-`.md`) | Whichever dependent packages are affected |
+
+No bump required for: `docs/**`, `test/**`, `.github/workflows/**`, governance files, `*.md`.
+
+### Bump type
+
+The orchestrator determines the bump type (major/minor/patch) by examining commit types and public API impact. When ambiguous, the orchestrator asks the user to confirm before delegating.
+
+| Commit type | API impact | SemVer increment |
+|---|---|---|
+| `feat` | New API | minor |
+| `feat!` / `BREAKING CHANGE:` | Breaking | major |
+| `fix`, `bugfix`, `refactor` | None | patch |
+| `chore`, `docs`, `test`, `ci` | None | **no bump** |
+
+### Execution
+
+The orchestrator delegates version file edits to the coder agent. The bump is included in the **same PR** as the feature or fix — not a follow-up PR.
+
+Files updated atomically per bump (see [docs/versioning.md](versioning.md) for full list):
+- `.csproj` `<Version>` element (source of truth)
+- `CLAUDE.md` Package Versions table
+- `docs/architecture.md` solution structure table
+- `CHANGELOG.md` or `CHANGELOG-CodeGenerators.md`
+
+### PR readiness gate
+
+A PR that changes non-markdown `src/` files is **not ready to merge** until the version bump is included. The CI `version-check` job enforces this by comparing the `.csproj` version against the latest git tag and failing if they are equal.
+
 ## Pull Request Policy
 
 ### When a PR is opened

--- a/docs/development.md
+++ b/docs/development.md
@@ -145,3 +145,27 @@ All projects have `<Nullable>enable</Nullable>`. The `netstandard2.0` target of 
 ### Test Assertion Style
 
 FluentAssertions (`Should()` syntax) is the preferred assertion library for new tests. Existing tests using xUnit `Assert.*` should not be migrated retroactively.
+
+---
+
+## Versioning
+
+Package versions follow [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html). See [versioning.md](versioning.md) for the full policy including bump triggers, bump type rules, and orchestrator authority.
+
+### CHANGELOG files
+
+| File | Package |
+|---|---|
+| [`CHANGELOG.md`](../CHANGELOG.md) | `Chatter.Rest.Hal` |
+| [`CHANGELOG-CodeGenerators.md`](../CHANGELOG-CodeGenerators.md) | `Chatter.Rest.Hal.CodeGenerators` |
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Update the `[Unreleased]` section when making changes that will be included in the next release.
+
+### Git tags
+
+CI automatically creates an annotated tag on each successful deploy to NuGet:
+
+| Package | Tag format | Example |
+|---|---|---|
+| `Chatter.Rest.Hal` | `hal/vX.Y.Z` | `hal/v1.2.0` |
+| `Chatter.Rest.Hal.CodeGenerators` | `codegen/vX.Y.Z` | `codegen/v0.4.0` |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -2,16 +2,11 @@
 
 ## Scope
 
-Two independently versioned NuGet packages:
+Packable packages and their source paths are defined in `CLAUDE.md` under the **Package Versions** and **Solution Structure** sections. The versioning policy applies to each packable package independently.
 
-| Package | Project |
-|---|---|
-| `Chatter.Rest.Hal` | `src/Chatter.Rest.Hal/` |
-| `Chatter.Rest.Hal.CodeGenerators` | `src/Chatter.Rest.Hal.CodeGenerators/` |
+Each package is versioned independently. A change to one package does not require a bump in another unless the change propagates through a public API dependency.
 
-`Chatter.Rest.Hal.Core` is an internal shared library — not packaged independently and has no version.
-
-Each package is versioned independently. A change to one package does not require a bump in the other unless the change propagates through a public API dependency.
+Internal shared libraries that are not packaged independently carry no version.
 
 ## SemVer Rules
 
@@ -25,20 +20,15 @@ Version format: `MAJOR.MINOR.PATCH`
 | MINOR | New backward-compatible public API surface (`feat` commits) |
 | PATCH | Bug fixes or internal refactors with no public API change (`fix`, `bugfix`, `refactor` commits) |
 
-**Pre-1.0 note:** `Chatter.Rest.Hal.CodeGenerators` is currently pre-1.0 (`0.x.y`). In pre-1.0, MINOR increments may include breaking changes per SemVer spec. Document breaking changes clearly in the CHANGELOG regardless.
+**Pre-1.0 note:** For packages at `0.x.y`, MINOR increments may include breaking changes per SemVer spec. Document breaking changes clearly in the CHANGELOG regardless.
 
 Pre-release labels (e.g., `1.2.0-beta.1`) are allowed but must be coordinated with the orchestrator.
 
 ## Bump Trigger
 
-A version bump is **required** when a PR merges changes to non-markdown files under the relevant package's `src/` directory:
+A version bump is **required** when a PR merges changes to non-markdown files under a packable package's `src/` directory (e.g., `src/<package-name>/**` excluding `*.md`). Refer to `CLAUDE.md` for the project's package list and source paths.
 
-| Package | Trigger path |
-|---|---|
-| `Chatter.Rest.Hal` | `src/Chatter.Rest.Hal/**` (excluding `*.md`) |
-| `Chatter.Rest.Hal.CodeGenerators` | `src/Chatter.Rest.Hal.CodeGenerators/**` (excluding `*.md`) |
-
-Changes to `src/Chatter.Rest.Hal.Core/**` may trigger a bump in either or both dependent packages if the change affects their public API surface.
+Changes to internal shared library source directories may trigger a bump in dependent packages if the change affects their public API surface.
 
 **No version bump required for:**
 - `docs/**`
@@ -46,7 +36,7 @@ Changes to `src/Chatter.Rest.Hal.Core/**` may trigger a bump in either or both d
 - `.github/workflows/**`
 - Governance files (`agent-system-policy.md`, `branching-pr-workflow.md`, `orchestrator.md`, etc.)
 - `CLAUDE.md`
-- `CHANGELOG.md` / `CHANGELOG-CodeGenerators.md`
+- CHANGELOG files
 - Any `*.md` file
 
 ## Bump Type Determination
@@ -73,26 +63,14 @@ The orchestrator **delegates version file edits to the coder agent**. The versio
 
 Files to update atomically when bumping version `X.Y.Z` for a package:
 
-**`Chatter.Rest.Hal`:**
-1. `src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj` — `<Version>X.Y.Z</Version>` (source of truth)
-2. `CLAUDE.md` — Package Versions table row for `Chatter.Rest.Hal`
-3. `docs/architecture.md` — Solution structure table row for `Chatter.Rest.Hal`
-4. `CHANGELOG.md` — Add release section `## [X.Y.Z] - YYYY-MM-DD` above `[Unreleased]`; add link at bottom
-
-**`Chatter.Rest.Hal.CodeGenerators`:**
-1. `src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj` — `<Version>X.Y.Z</Version>` (source of truth)
-2. `CLAUDE.md` — Package Versions table row for `Chatter.Rest.Hal.CodeGenerators`
-3. `docs/architecture.md` — Solution structure table row for `Chatter.Rest.Hal.CodeGenerators`
-4. `CHANGELOG-CodeGenerators.md` — Add release section `## [X.Y.Z] - YYYY-MM-DD` above `[Unreleased]`; add link at bottom
+1. `src/<package-name>/<package-name>.csproj` — `<Version>X.Y.Z</Version>` (source of truth)
+2. `CLAUDE.md` — Package Versions table row for the package
+3. Project architecture/docs table entry for the package (if one exists — refer to CLAUDE.md Documentation Index)
+4. Package CHANGELOG file — add release section `## [X.Y.Z] - YYYY-MM-DD` above `[Unreleased]`; update comparison link at bottom
 
 ## CHANGELOG Convention
 
-Each package maintains its own CHANGELOG at the repository root:
-
-| File | Package |
-|---|---|
-| `CHANGELOG.md` | `Chatter.Rest.Hal` |
-| `CHANGELOG-CodeGenerators.md` | `Chatter.Rest.Hal.CodeGenerators` |
+Each package maintains its own CHANGELOG file. Filename conventions and the mapping of CHANGELOG files to packages are defined in project documentation (see `CLAUDE.md` and `docs/development.md`).
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
@@ -108,8 +86,10 @@ Tag format:
 
 | Package | Tag format | Example |
 |---|---|---|
-| `Chatter.Rest.Hal` | `hal/vX.Y.Z` | `hal/v1.2.0` |
-| `Chatter.Rest.Hal.CodeGenerators` | `codegen/vX.Y.Z` | `codegen/v0.4.0` |
+| Package A | `<prefix>/vX.Y.Z` | `mylib/v1.2.0` |
+| Package B | `<prefix>/vX.Y.Z` | `mygen/v0.4.0` |
+
+Each project defines its tag prefixes per package. The CI `tag` job reads the version from the `.csproj` and the prefix from the workflow configuration.
 
 Tags are annotated (not lightweight). The CI `tag` job runs after `deploy` succeeds on `main`, reads the version from the `.csproj`, and creates + pushes the tag if it does not already exist.
 
@@ -120,6 +100,6 @@ These tags serve as:
 
 ## Version Source of Truth
 
-The `<Version>` element in each `.csproj` is the canonical version. All other references (`CLAUDE.md`, `docs/architecture.md`) are informational mirrors that must be kept in sync during every version bump.
+The `<Version>` element in each `.csproj` is the canonical version. All other references (documentation tables, `CLAUDE.md`) are informational mirrors that must be kept in sync during every version bump.
 
 CI reads the `.csproj` version at pack time. The CI version-check job compares the `.csproj` version against the latest matching git tag and fails the PR if they are equal (version not bumped).

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,125 @@
+# Versioning Policy
+
+## Scope
+
+Two independently versioned NuGet packages:
+
+| Package | Project |
+|---|---|
+| `Chatter.Rest.Hal` | `src/Chatter.Rest.Hal/` |
+| `Chatter.Rest.Hal.CodeGenerators` | `src/Chatter.Rest.Hal.CodeGenerators/` |
+
+`Chatter.Rest.Hal.Core` is an internal shared library — not packaged independently and has no version.
+
+Each package is versioned independently. A change to one package does not require a bump in the other unless the change propagates through a public API dependency.
+
+## SemVer Rules
+
+This repository follows [Semantic Versioning 2.0.0](https://semver.org/spec/v2.0.0.html).
+
+Version format: `MAJOR.MINOR.PATCH`
+
+| Increment | When |
+|---|---|
+| MAJOR | Breaking change to the public API (removal, rename, signature change, behavior contract change) |
+| MINOR | New backward-compatible public API surface (`feat` commits) |
+| PATCH | Bug fixes or internal refactors with no public API change (`fix`, `bugfix`, `refactor` commits) |
+
+**Pre-1.0 note:** `Chatter.Rest.Hal.CodeGenerators` is currently pre-1.0 (`0.x.y`). In pre-1.0, MINOR increments may include breaking changes per SemVer spec. Document breaking changes clearly in the CHANGELOG regardless.
+
+Pre-release labels (e.g., `1.2.0-beta.1`) are allowed but must be coordinated with the orchestrator.
+
+## Bump Trigger
+
+A version bump is **required** when a PR merges changes to non-markdown files under the relevant package's `src/` directory:
+
+| Package | Trigger path |
+|---|---|
+| `Chatter.Rest.Hal` | `src/Chatter.Rest.Hal/**` (excluding `*.md`) |
+| `Chatter.Rest.Hal.CodeGenerators` | `src/Chatter.Rest.Hal.CodeGenerators/**` (excluding `*.md`) |
+
+Changes to `src/Chatter.Rest.Hal.Core/**` may trigger a bump in either or both dependent packages if the change affects their public API surface.
+
+**No version bump required for:**
+- `docs/**`
+- `test/**`
+- `.github/workflows/**`
+- Governance files (`agent-system-policy.md`, `branching-pr-workflow.md`, `orchestrator.md`, etc.)
+- `CLAUDE.md`
+- `CHANGELOG.md` / `CHANGELOG-CodeGenerators.md`
+- Any `*.md` file
+
+## Bump Type Determination
+
+The **orchestrator** determines the bump type by examining:
+1. The conventional commit type(s) on the branch (`feat`, `fix`, `refactor`, etc.)
+2. Whether any public API surface was added, changed, or removed
+3. Whether any breaking changes are present (indicated by `!` suffix or `BREAKING CHANGE:` footer)
+
+| Commit type | Public API impact | SemVer increment |
+|---|---|---|
+| `feat` | New API surface | MINOR |
+| `feat!` or `BREAKING CHANGE:` footer | Breaking change | MAJOR |
+| `fix` / `bugfix` | No API change | PATCH |
+| `refactor` | No API change | PATCH |
+| `refactor!` | Breaking change | MAJOR |
+| `chore` / `docs` / `test` / `ci` | None | **No bump** |
+
+When in doubt, the orchestrator asks the user to confirm the bump type before delegating the version edit.
+
+## Bump Execution
+
+The orchestrator **delegates version file edits to the coder agent**. The version bump is included in the same PR as the feature or fix — not as a follow-up PR.
+
+Files to update atomically when bumping version `X.Y.Z` for a package:
+
+**`Chatter.Rest.Hal`:**
+1. `src/Chatter.Rest.Hal/Chatter.Rest.Hal.csproj` — `<Version>X.Y.Z</Version>` (source of truth)
+2. `CLAUDE.md` — Package Versions table row for `Chatter.Rest.Hal`
+3. `docs/architecture.md` — Solution structure table row for `Chatter.Rest.Hal`
+4. `CHANGELOG.md` — Add release section `## [X.Y.Z] - YYYY-MM-DD` above `[Unreleased]`; add link at bottom
+
+**`Chatter.Rest.Hal.CodeGenerators`:**
+1. `src/Chatter.Rest.Hal.CodeGenerators/Chatter.Rest.Hal.CodeGenerators.csproj` — `<Version>X.Y.Z</Version>` (source of truth)
+2. `CLAUDE.md` — Package Versions table row for `Chatter.Rest.Hal.CodeGenerators`
+3. `docs/architecture.md` — Solution structure table row for `Chatter.Rest.Hal.CodeGenerators`
+4. `CHANGELOG-CodeGenerators.md` — Add release section `## [X.Y.Z] - YYYY-MM-DD` above `[Unreleased]`; add link at bottom
+
+## CHANGELOG Convention
+
+Each package maintains its own CHANGELOG at the repository root:
+
+| File | Package |
+|---|---|
+| `CHANGELOG.md` | `Chatter.Rest.Hal` |
+| `CHANGELOG-CodeGenerators.md` | `Chatter.Rest.Hal.CodeGenerators` |
+
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Each release section uses these subsections as needed: `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`.
+
+The `[Unreleased]` section at the top accumulates entries for the next release. When the orchestrator bumps the version, it converts `[Unreleased]` entries into a dated release section and resets `[Unreleased]` to empty.
+
+## Git Tags
+
+A git tag is created automatically by CI after each successful deploy to NuGet.
+
+Tag format:
+
+| Package | Tag format | Example |
+|---|---|---|
+| `Chatter.Rest.Hal` | `hal/vX.Y.Z` | `hal/v1.2.0` |
+| `Chatter.Rest.Hal.CodeGenerators` | `codegen/vX.Y.Z` | `codegen/v0.4.0` |
+
+Tags are annotated (not lightweight). The CI `tag` job runs after `deploy` succeeds on `main`, reads the version from the `.csproj`, and creates + pushes the tag if it does not already exist.
+
+These tags serve as:
+- The version anchor for CI version-check validation on future PRs
+- GitHub Releases anchors
+- NuGet package traceability points
+
+## Version Source of Truth
+
+The `<Version>` element in each `.csproj` is the canonical version. All other references (`CLAUDE.md`, `docs/architecture.md`) are informational mirrors that must be kept in sync during every version bump.
+
+CI reads the `.csproj` version at pack time. The CI version-check job compares the `.csproj` version against the latest matching git tag and fails the PR if they are equal (version not bumped).


### PR DESCRIPTION
## Summary

- **`docs/versioning.md`** (new) — full SemVer policy: bump rules, trigger paths, orchestrator authority, CHANGELOG convention, git tag format
- **CI workflows** — expand push triggers to all valid branch prefixes (`feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `docs/`, `test/`, `ci/`); add `version-check` job (PR gate: fails if `.csproj` version equals latest git tag when non-markdown `src/` files changed); add `tag` job (auto-creates annotated `hal/vX.Y.Z` / `codegen/vX.Y.Z` tags after successful deploy to `main`)
- **`CHANGELOG.md` + `CHANGELOG-CodeGenerators.md`** (new) — Keep a Changelog stubs with `[Unreleased]` sections and comparison links anchored to current versions
- **`docs/branching-pr-workflow.md`** — Version Bump Policy section (trigger paths, bump-type table, same-PR execution rule, PR readiness gate)
- **`agent-system-policy.md`** — authority rows: orchestrator decides bump type, coder executes file edits
- **`.claude/agents/orchestrator.md`** — version bump check wired into Execution Algorithm (step 10) and delegation template
- **`CLAUDE.md` + `docs/development.md`** — cross-references to versioning.md and CHANGELOG files

## Versioning rules

| Trigger | No trigger |
|---|---|
| Non-markdown files in `src/Chatter.Rest.Hal/**` | `docs/**`, `test/**`, `.github/workflows/**` |
| Non-markdown files in `src/Chatter.Rest.Hal.CodeGenerators/**` | Governance files, `*.md`, `CHANGELOG*.md` |

| Commit type | SemVer |
|---|---|
| `feat` (new API) | minor |
| `feat!` / `BREAKING CHANGE:` | major |
| `fix`, `bugfix`, `refactor` | patch |
| `chore`, `docs`, `test`, `ci` | none |

## Test plan

- [ ] Open a PR with `src/` changes and no version bump — CI `version-check` should fail
- [ ] Open a PR with `src/` changes + version bump — CI `version-check` should pass
- [ ] Open a PR with docs/test-only changes — CI `version-check` should skip
- [ ] Merge a version-bumped PR to `main` — CI `tag` job should create `hal/vX.Y.Z` tag
- [ ] Verify `chore/` and other non-`feature/` branch pushes now trigger CI build

## Post-merge

After this PR merges, seed the initial tags:

```bash
git tag -a hal/v1.1.0 -m "Chatter.Rest.Hal v1.1.0" <merge-sha>
git tag -a codegen/v0.3.0 -m "Chatter.Rest.Hal.CodeGenerators v0.3.0" <merge-sha>
git push origin hal/v1.1.0 codegen/v0.3.0
```

This bootstraps the `version-check` CI gate for future PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)