### PR TITLE
docs: add pagination and bash conversion to GraphQL reference

### DIFF
--- a/.claude/skills/run-codex-review-loop/github-pr-review-graphql.md
+++ b/.claude/skills/run-codex-review-loop/github-pr-review-graphql.md
@@ -6,18 +6,19 @@ Resolvable pull request review threads are GraphQL objects. Do not try to resolv
 
 ## Fetch review threads
 
-```powershell
-gh api graphql `
-  -f owner="OWNER" `
-  -f repo="REPO" `
-  -F pr=123 `
+```bash
+gh api graphql \
+  -f owner="OWNER" \
+  -f repo="REPO" \
+  -F pr=123 \
   -f query='
-query($owner: String!, $repo: String!, $pr: Int!) {
+query($owner: String!, $repo: String!, $pr: Int!, $threadCursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
       number
       url
-      reviewThreads(first: 100) {
+      reviewThreads(first: 100, after: $threadCursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           isResolved
@@ -25,11 +26,10 @@ query($owner: String!, $repo: String!, $pr: Int!) {
           path
           line
           comments(first: 20) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
-              author {
-                login
-              }
+              author { login }
               body
               createdAt
               url
@@ -45,12 +45,39 @@ query($owner: String!, $repo: String!, $pr: Int!) {
 }'
 ```
 
+## Fetch comments for a review thread
+
+```bash
+gh api graphql \
+  -f threadId="THREAD_ID" \
+  -f query='
+query($threadId: ID!, $cursor: String) {
+  node(id: $threadId) {
+    ... on PullRequestReviewThread {
+      comments(first: 20, after: $cursor) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          author { login }
+          body
+          createdAt
+          url
+          path
+          line
+          diffHunk
+        }
+      }
+    }
+  }
+}'
+```
+
 ## Reply to a review thread
 
-```powershell
-gh api graphql `
-  -f threadId="THREAD_ID" `
-  -f body="Fixed in COMMIT_SHA. Summary: ..." `
+```bash
+gh api graphql \
+  -f threadId="THREAD_ID" \
+  -f body="Fixed in COMMIT_SHA. Summary: ..." \
   -f query='
 mutation($threadId: ID!, $body: String!) {
   addPullRequestReviewThreadReply(
@@ -69,9 +96,9 @@ mutation($threadId: ID!, $body: String!) {
 
 ## Resolve a review thread
 
-```powershell
-gh api graphql `
-  -f threadId="THREAD_ID" `
+```bash
+gh api graphql \
+  -f threadId="THREAD_ID" \
   -f query='
 mutation($threadId: ID!) {
   resolveReviewThread(input: { threadId: $threadId }) {
@@ -87,21 +114,20 @@ mutation($threadId: ID!) {
 
 Top-level PR comments are issue comments because every PR is also an issue. Use `gh pr view` or GitHub GraphQL issue comments when needed.
 
-```powershell
-gh api graphql `
-  -f owner="OWNER" `
-  -f repo="REPO" `
-  -F pr=123 `
+```bash
+gh api graphql \
+  -f owner="OWNER" \
+  -f repo="REPO" \
+  -F pr=123 \
   -f query='
-query($owner: String!, $repo: String!, $pr: Int!) {
+query($owner: String!, $repo: String!, $pr: Int!, $commentCursor: String) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $pr) {
-      comments(first: 100) {
+      comments(first: 100, after: $commentCursor) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
-          author {
-            login
-          }
+          author { login }
           body
           createdAt
           url
@@ -111,6 +137,20 @@ query($owner: String!, $repo: String!, $pr: Int!) {
   }
 }'
 ```
+
+## Pagination
+
+### Review threads
+Paginate `reviewThreads` using `$threadCursor` until `pageInfo.hasNextPage` is `false`. Accumulate all thread nodes before classifying.
+
+### Thread comments
+The initial thread fetch retrieves up to 20 comments per thread inline. If a thread's `comments.pageInfo.hasNextPage` is `true`, use **Fetch comments for a review thread** with that thread's node ID and `comments.pageInfo.endCursor` to retrieve subsequent pages. Each thread requires its own cursor — do not reuse cursors across threads.
+
+### Top-level PR comments
+Paginate `comments` using `$commentCursor` until `pageInfo.hasNextPage` is `false`. Accumulate all comment nodes before classifying.
+
+### General rule
+Do not classify or route feedback from a partial (first-page-only) result set.
 
 ## Author Filtering
 


### PR DESCRIPTION
## Summary

- Fixes 3 P1 gaps identified in sibling repo (Chatter.Rest.UriTemplates PR #11) that apply equally here
- Converts all shell blocks from PowerShell backtick syntax to bash `\` continuations (consistent with `watch-pr-feedback/SKILL.md` already converted in #80)

## Changes

- `reviewThreads` query: adds `$threadCursor` param, `after: $threadCursor`, `pageInfo { hasNextPage endCursor }` — prevents silent truncation on PRs with >100 threads
- `comments(first: 20)` inside thread nodes: adds `pageInfo { hasNextPage endCursor }` — enables per-thread comment pagination
- New **"Fetch comments for a review thread"** section: `node(id)` query with independent `$cursor` for paginating a single thread's comments beyond 20
- Top-level `comments` query: adds `$commentCursor` param, `after: $commentCursor`, `pageInfo { hasNextPage endCursor }` — prevents truncation on large PRs
- New **Pagination** section: documents iteration pattern for all three connections + general rule against classifying partial result sets

## Test plan

- [ ] Verify `reviewThreads` query includes `$threadCursor` and `pageInfo`
- [ ] Verify `comments` inside thread nodes includes `pageInfo`
- [ ] Verify new per-thread `node(id)` query is present with independent cursor
- [ ] Verify top-level `comments` query includes `$commentCursor` and `pageInfo`
- [ ] Verify Pagination section covers all three connections
- [ ] Verify all shell blocks use bash syntax (no PowerShell backticks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)